### PR TITLE
Refine mobile dashboard interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <link href="https://unpkg.com/gridjs/dist/theme/mermaid.min.css" rel="stylesheet"/>
   <link href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700;800&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="style.V2.css"/>
+  <link rel="stylesheet" href="style.css"/>
 </head>
 <body>
   <!-- TOPBAR -->
@@ -46,16 +46,59 @@
     <!-- CARD DE FILTROS -->
     <section class="card card--filters">
       <header class="card__header">
-        <div class="title-subtitle">
-          <h2>POBJ Produções</h2>
-          <p class="muted">
-            Acompanhe dados atualizados de performance.
-            <span class="tooltip">
-              <span class="chip-info">?</span>
-            </span>
-          </p>
+        <div class="filters-hero">
+          <div class="title-subtitle">
+            <h2>POBJ Produções</h2>
+            <p class="muted">Acompanhe dados atualizados de performance.</p>
+          </div>
+          <div id="mobile-carousel" class="mobile-carousel" aria-label="Destaques do painel">
+            <button type="button" class="mobile-carousel__control mobile-carousel__control--prev" data-carousel-prev aria-label="Slide anterior">
+              <i class="ti ti-chevron-left" aria-hidden="true"></i>
+            </button>
+            <div class="mobile-carousel__track">
+              <article class="mobile-carousel__slide is-active" data-slide="0">
+                <div class="mobile-carousel__icon"><i class="ti ti-target"></i></div>
+                <div class="mobile-carousel__content">
+                  <h4 class="mobile-carousel__title">Sprint PJ em foco</h4>
+                  <p class="mobile-carousel__desc">Veja metas e elegibilidade da campanha atual em segundos.</p>
+                </div>
+              </article>
+              <article class="mobile-carousel__slide" data-slide="1">
+                <div class="mobile-carousel__icon"><i class="ti ti-arrows-double-ne-sw"></i></div>
+                <div class="mobile-carousel__content">
+                  <h4 class="mobile-carousel__title">Simuladores ágeis</h4>
+                  <p class="mobile-carousel__desc">Projete cenários da equipe ou individuais com ajustes rápidos.</p>
+                </div>
+              </article>
+              <article class="mobile-carousel__slide" data-slide="2">
+                <div class="mobile-carousel__icon"><i class="ti ti-device-analytics"></i></div>
+                <div class="mobile-carousel__content">
+                  <h4 class="mobile-carousel__title">Ranking personalizado</h4>
+                  <p class="mobile-carousel__desc">Compare sua posição preservando os dados dos demais.</p>
+                </div>
+              </article>
+            </div>
+            <button type="button" class="mobile-carousel__control mobile-carousel__control--next" data-carousel-next aria-label="Próximo slide">
+              <i class="ti ti-chevron-right" aria-hidden="true"></i>
+            </button>
+            <div class="mobile-carousel__dots" role="tablist" aria-label="Navegação do carrossel">
+              <button type="button" class="mobile-carousel__dot" data-slide-to="0" aria-label="Ver destaque da sprint" aria-current="true"></button>
+              <button type="button" class="mobile-carousel__dot" data-slide-to="1" aria-label="Ver destaque dos simuladores"></button>
+              <button type="button" class="mobile-carousel__dot" data-slide-to="2" aria-label="Ver destaque do ranking"></button>
+            </div>
+          </div>
+        </div>
+        <div class="card__actions card__actions--mobile">
+          <button id="btn-mobile-filtros" class="btn btn--ghost btn--mobile-filter" type="button" aria-expanded="false" aria-label="Abrir filtros">
+            <i class="ti ti-filter" aria-hidden="true"></i>
+            <span class="btn-label">Filtros</span>
+          </button>
         </div>
       </header>
+
+      <button id="btn-fechar-filtros" class="icon-btn filters-mobile-close" type="button" aria-label="Fechar filtros">
+        <i class="ti ti-x" aria-hidden="true"></i>
+      </button>
 
       <div class="filters">
         <div class="filters__group">
@@ -126,9 +169,26 @@
 
     <!-- TABS -->
     <section class="tabs">
-      <button class="tab is-active" data-view="cards">Resumo</button>
-      <button class="tab" data-view="table">Detalhamento</button>
-      <button class="tab" data-view="exec">Visão executiva</button>
+      <button class="tab is-active" data-view="cards">
+        <span class="tab-icon ti ti-dashboard"></span>
+        <span class="tab-label">Resumo</span>
+      </button>
+      <button class="tab" data-view="table">
+        <span class="tab-icon ti ti-list-tree"></span>
+        <span class="tab-label">Detalhamento</span>
+      </button>
+      <button class="tab" data-view="ranking">
+        <span class="tab-icon ti ti-trophy"></span>
+        <span class="tab-label">Ranking</span>
+      </button>
+      <button class="tab" data-view="exec">
+        <span class="tab-icon ti ti-chart-line"></span>
+        <span class="tab-label">Visão executiva</span>
+      </button>
+      <button class="tab" data-view="campanhas">
+        <span class="tab-icon ti ti-speakerphone"></span>
+        <span class="tab-label">Campanhas</span>
+      </button>
       <div class="tabs__aside">
         <small class="muted"><span id="lbl-atualizacao"></span></small>
       </div>
@@ -145,9 +205,10 @@
         <header class="card__header">
           <h3>Detalhamento</h3>
           <div class="card__actions">
-            <input id="busca" class="input input--sm" type="search" placeholder="Buscar gerente/agência…"/>
-            <!-- Campo de contrato AGORA é da TABELA -->
-            <input id="f-contrato-table" class="input input--sm" type="search" placeholder="Contrato (Ex.: CT-2025-001234)"/>
+            <div class="card__search-autocomplete">
+              <input id="busca" class="input input--sm" type="search" placeholder="Contrato (Ex.: CT-2025-001234)" autocomplete="off" aria-autocomplete="list" aria-expanded="false" aria-owns="contract-suggest"/>
+              <div id="contract-suggest" class="contract-suggest" role="listbox" aria-label="Sugestões de contratos" hidden></div>
+            </div>
           </div>
         </header>
         <div id="gridRanking"></div>
@@ -155,21 +216,126 @@
     </section>
 
     <!-- VIEW: VISÃO EXECUTIVA -->
-    <section id="view-exec" class="hidden">
-      <section class="card">
-        <header class="card__header">
-          <h3>Visão executiva</h3>
+    <section id="view-exec" class="hidden view-panel">
+      <section class="card card--exec">
+        <header class="card__header exec-head">
+          <div class="title-subtitle">
+            <h3>Visão executiva</h3>
+            <div class="muted" id="exec-context"></div>
+          </div>
         </header>
-        <p class="muted">Em breve.</p>
+
+        <div id="exec-kpis" class="exec-kpis"></div>
+
+        <section class="exec-panel exec-span-2 exec-chart">
+          <div class="exec-h">
+            <span id="exec-chart-title">Evolução do mês</span>
+            <div class="segmented seg-mini" id="exec-chart-toggle" role="tablist" aria-label="Modo do gráfico">
+              <button type="button" class="seg-btn is-active" data-chart="diario">Dia a dia</button>
+              <button type="button" class="seg-btn" data-chart="mensal">Visão mês</button>
+            </div>
+          </div>
+          <div id="exec-chart" class="chart" role="img" aria-label="Evolução diária com linhas de meta e realizado"></div>
+          <div id="exec-chart-legend" class="chart-legend">
+            <span class="legend-item"><span class="legend-swatch legend-swatch--bars"></span>Diário realizado (barras)</span>
+            <span class="legend-item"><span class="legend-swatch legend-swatch--real"></span>Realizado acumulado (linha)</span>
+            <span class="legend-item"><span class="legend-swatch legend-swatch--meta"></span>Meta acumulada (linha)</span>
+          </div>
+        </section>
+
+        <div class="exec-grid">
+          <section class="exec-panel" id="exec-rank-panel">
+            <div class="exec-h">
+              <span id="exec-rank-title">Desempenho por unidade</span>
+              <div class="segmented seg-mini" role="tablist" aria-label="Ordenação">
+                <button type="button" class="seg-btn is-active" data-rk="top">Top 5</button>
+                <button type="button" class="seg-btn" data-rk="bottom">Bottom 5</button>
+              </div>
+            </div>
+            <div id="exec-rank" class="rank-mini"></div>
+          </section>
+
+          <section class="exec-panel" id="exec-status-panel">
+            <div class="exec-h">
+              <span id="exec-status-title">Status das unidades</span>
+              <div class="segmented seg-mini" role="tablist" aria-label="Status">
+                <button type="button" class="seg-btn" data-st="hit">Atingidas</button>
+                <button type="button" class="seg-btn is-active" data-st="quase">Quase lá</button>
+                <button type="button" class="seg-btn" data-st="longe">Longe</button>
+              </div>
+            </div>
+            <div id="exec-status-list" class="list-mini"></div>
+          </section>
+
+          <section class="exec-panel exec-span-2">
+            <h4 class="exec-h"><span id="exec-heatmap-title">Heatmap</span></h4>
+            <div id="exec-heatmap" class="hm"></div>
+          </section>
+        </div>
+      </section>
+    </section>
+
+    <!-- VIEW: CAMPANHAS -->
+    <section id="view-campanhas" class="hidden view-panel">
+      <section class="card card--campanhas">
+        <header class="card__header camp-header">
+          <div class="title-subtitle">
+            <h3>Campanhas</h3>
+            <p class="muted" id="camp-cycle"></p>
+          </div>
+          <div class="camp-header__controls">
+            <label for="campanha-sprint" class="muted">Sprint</label>
+            <select id="campanha-sprint" class="input input--sm"></select>
+          </div>
+        </header>
+
+        <div class="camp-hero">
+          <div class="camp-hero__info">
+            <p id="camp-note"></p>
+            <div class="camp-period">
+              <i class="ti ti-calendar-stats" aria-hidden="true"></i>
+              <span id="camp-period"></span>
+            </div>
+          </div>
+          <div class="camp-hero__stats" id="camp-headline"></div>
+        </div>
+
+        <div class="camp-kpi-grid" id="camp-kpis"></div>
+      </section>
+
+      <section class="card card--camp-sims">
+        <header class="card__header">
+          <div class="title-subtitle">
+            <h4>Simuladores da sprint</h4>
+            <p class="muted">Projete rapidamente o resultado da equipe ou de um gerente ajustando o atingimento de cada indicador.</p>
+          </div>
+        </header>
+        <div class="sim-grid">
+          <article id="sim-equipe" class="sim-card"></article>
+          <article id="sim-individual" class="sim-card"></article>
+        </div>
+        <p class="sim-footnote muted">Cada indicador respeita o intervalo de 0% a 150% para cálculo de pontos. Valores acima disso são desconsiderados.</p>
+      </section>
+
+      <section class="card card--camp-ranking">
+        <header class="card__header">
+          <div class="title-subtitle">
+            <h4>Ranking da campanha</h4>
+            <p class="muted" id="camp-ranking-desc">Acompanhe a performance das regionais e a elegibilidade frente aos critérios mínimos.</p>
+          </div>
+        </header>
+        <div id="camp-ranking"></div>
       </section>
     </section>
   </main>
+
+  <div id="filters-backdrop" class="filters-backdrop" hidden></div>
 
   <footer class="footer">
     <span>Bradesco POBJ • v1.0 </span>
   </footer>
 
   <script src="https://unpkg.com/gridjs/dist/gridjs.umd.js"></script>
-  <script src="script.v2.js"></script>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -21,6 +21,78 @@ const $  = (s) => document.querySelector(s);
 const $$ = (s) => document.querySelectorAll(s);
 const fmtBRL = new Intl.NumberFormat("pt-BR", { style:"currency", currency:"BRL" });
 const fmtINT = new Intl.NumberFormat("pt-BR");
+const fmtONE = new Intl.NumberFormat("pt-BR", { minimumFractionDigits:1, maximumFractionDigits:1 });
+const setActiveTab = (viewId = "cards") => {
+  const tabs = Array.from($$(".tab"));
+  const target = tabs.some(tab => (tab.dataset.view || "") === viewId) ? viewId : "cards";
+  tabs.forEach(tab => {
+    const expected = tab.dataset.view || "";
+    tab.classList.toggle("is-active", expected === target);
+  });
+  const sidebarLinks = Array.from(document.querySelectorAll(".sidebar__link"));
+  if (sidebarLinks.length) {
+    sidebarLinks.forEach(link => {
+      const route = link.dataset.route || "";
+      if (target === "campanhas") {
+        link.classList.toggle("is-active", route === "campanhas");
+      } else if (["cards", "table", "ranking", "exec"].includes(target)) {
+        link.classList.toggle("is-active", route === "pobj");
+      }
+    });
+  }
+};
+const fmtBRLParts = fmtBRL.formatToParts(1);
+const CURRENCY_SYMBOL = fmtBRLParts.find(p => p.type === "currency")?.value || "R$";
+const CURRENCY_LITERAL = fmtBRLParts.find(p => p.type === "literal")?.value || " ";
+const SUFFIX_RULES = [
+  { value: 1_000_000_000_000, singular: "trilhão", plural: "trilhões" },
+  { value: 1_000_000_000,     singular: "bilhão",  plural: "bilhões" },
+  { value: 1_000_000,         singular: "milhão",  plural: "milhões" },
+  { value: 1_000,             singular: "mil",     plural: "mil" }
+];
+const MOTIVOS_CANCELAMENTO = [
+  "Solicitação do cliente",
+  "Inadimplência",
+  "Renovação antecipada",
+  "Ajuste comercial",
+  "Migração de produto"
+];
+
+const RANKING_DIRECTORIAS = [
+  { id: "DR 01", nome: "Norte & Nordeste" },
+  { id: "DR 02", nome: "Sudeste" },
+  { id: "DR 03", nome: "Sul & Centro-Oeste" }
+];
+
+const RANKING_GERENCIAS = [
+  { id: "GR 01", nome: "Regional Fortaleza", diretoria: "DR 01" },
+  { id: "GR 02", nome: "Regional Recife", diretoria: "DR 01" },
+  { id: "GR 03", nome: "Regional São Paulo", diretoria: "DR 02" },
+  { id: "GR 04", nome: "Regional Curitiba", diretoria: "DR 03" }
+];
+
+const RANKING_AGENCIAS = [
+  { id: "Ag 1001", nome: "Agência 1001 • Fortaleza Centro", gerencia: "GR 01" },
+  { id: "Ag 1002", nome: "Agência 1002 • Recife Boa Vista", gerencia: "GR 02" },
+  { id: "Ag 1003", nome: "Agência 1003 • Curitiba Batel", gerencia: "GR 04" },
+  { id: "Ag 1004", nome: "Agência 1004 • Avenida Paulista", gerencia: "GR 03" }
+];
+
+const RANKING_GERENTES = [
+  { id: "Gerente 1", nome: "Ana Lima" },
+  { id: "Gerente 2", nome: "Paulo Nunes" },
+  { id: "Gerente 3", nome: "Juliana Prado" },
+  { id: "Gerente 4", nome: "Bruno Garcia" },
+  { id: "Gerente 5", nome: "Carla Menezes" }
+];
+
+const CURRENT_USER_CONTEXT = {
+  diretoria: "DR 01",
+  gerencia: "GR 01",
+  agencia: "Ag 1001",
+  gerenteGestao: "GG 01",
+  gerente: "Gerente 1"
+};
 
 /* ===== Ajusta altura conforme topbar (svh) ===== */
 const setTopbarH = () => {
@@ -40,20 +112,21 @@ const TABLE_VIEWS = [
   { id:"gerente",   label:"Gerente",            key:"gerente" },
   { id:"familia",   label:"Família",            key:"familia" },
   { id:"prodsub",   label:"Produto/Subproduto", key:"prodOrSub" },
+  { id:"contrato",  label:"Contratos",          key:"contrato" },
 ];
 
 /* === Seções e cards === */
 const CARD_SECTIONS_DEF = [
-  { id:"financeiro", label:"FINANCEIRO", items:[
-    { id:"rec_vencidos_59",     nome:"Recuperação de Vencidos até 59 dias",      icon:"ti ti-rotate-rectangle", peso:6, metric:"valor" },
-    { id:"rec_vencidos_50mais", nome:"Recuperação de Vencidos acima de 50 dias", icon:"ti ti-rotate-rectangle", peso:5, metric:"valor" },
-    { id:"rec_credito",         nome:"Recuperação de Crédito",                    icon:"ti ti-cash",             peso:5, metric:"valor" },
-  ]},
   { id:"captacao", label:"CAPTAÇÃO", items:[
     { id:"captacao_bruta",   nome:"Captação Bruta",                           icon:"ti ti-pig-money",       peso:4, metric:"valor" },
     { id:"captacao_liquida", nome:"Captação Líquida",                         icon:"ti ti-arrows-exchange", peso:4, metric:"valor" },
     { id:"portab_prev",      nome:"Portabilidade de Previdência Privada",     icon:"ti ti-shield-check",    peso:3, metric:"valor" },
     { id:"centralizacao",    nome:"Centralização de Caixa",                   icon:"ti ti-briefcase",       peso:3, metric:"valor" },
+  ]},
+  { id:"financeiro", label:"FINANCEIRO", items:[
+    { id:"rec_vencidos_59",     nome:"Recuperação de Vencidos até 59 dias",      icon:"ti ti-rotate-rectangle", peso:6, metric:"valor" },
+    { id:"rec_vencidos_50mais", nome:"Recuperação de Vencidos acima de 50 dias", icon:"ti ti-rotate-rectangle", peso:5, metric:"valor" },
+    { id:"rec_credito",         nome:"Recuperação de Crédito",                    icon:"ti ti-cash",             peso:5, metric:"valor" },
   ]},
   { id:"credito", label:"CRÉDITO", items:[
     { id:"prod_credito_pj", nome:"Produção de Crédito PJ",               icon:"ti ti-building-bank",  peso:8, metric:"valor" },
@@ -86,6 +159,275 @@ const PRODUCT_INDEX = (() => {
   return map;
 })();
 
+const CAMPAIGN_UNIT_DATA = [
+  { id: "nn-atlas", diretoria: "DR 01", diretoriaNome: "Norte & Nordeste", gerenciaRegional: "GR 01", regional: "Regional Fortaleza", gerenteGestao: "GG 01", agenciaCodigo: "Ag 1001", agencia: "Agência 1001 • Fortaleza Centro", segmento: "Negócios", produtoId: "captacao_bruta", subproduto: "Aplicação", gerente: "Gerente 1", gerenteNome: "Ana Lima", carteira: "Carteira Atlas", linhas: 132.4, cash: 118.2, conquista: 112.6, atividade: true, data: "2025-09-15" },
+  { id: "nn-delta", diretoria: "DR 01", diretoriaNome: "Norte & Nordeste", gerenciaRegional: "GR 01", regional: "Regional Fortaleza", gerenteGestao: "GG 01", agenciaCodigo: "Ag 1001", agencia: "Agência 1001 • Fortaleza Centro", segmento: "Negócios", produtoId: "captacao_liquida", subproduto: "Resgate", gerente: "Gerente 1", gerenteNome: "Ana Lima", carteira: "Carteira Delta", linhas: 118.3, cash: 109.5, conquista: 104.1, atividade: true, data: "2025-09-16" },
+  { id: "nn-iguatu", diretoria: "DR 01", diretoriaNome: "Norte & Nordeste", gerenciaRegional: "GR 02", regional: "Regional Recife", gerenteGestao: "GG 02", agenciaCodigo: "Ag 1002", agencia: "Agência 1002 • Recife Boa Vista", segmento: "Empresas", produtoId: "prod_credito_pj", subproduto: "À vista", gerente: "Gerente 2", gerenteNome: "Paulo Nunes", carteira: "Carteira Iguatu", linhas: 124.2, cash: 110.3, conquista: 102.1, atividade: true, data: "2025-09-12" },
+  { id: "nn-sertao", diretoria: "DR 01", diretoriaNome: "Norte & Nordeste", gerenciaRegional: "GR 02", regional: "Regional Recife", gerenteGestao: "GG 02", agenciaCodigo: "Ag 1002", agencia: "Agência 1002 • Recife Boa Vista", segmento: "Empresas", produtoId: "centralizacao", subproduto: "Parcelado", gerente: "Gerente 2", gerenteNome: "Paulo Nunes", carteira: "Carteira Sertão", linhas: 98.4, cash: 94.6, conquista: 96.8, atividade: false, data: "2025-09-09" },
+  { id: "sd-horizonte", diretoria: "DR 02", diretoriaNome: "Sudeste", gerenciaRegional: "GR 03", regional: "Regional São Paulo", gerenteGestao: "GG 03", agenciaCodigo: "Ag 1004", agencia: "Agência 1004 • Avenida Paulista", segmento: "Empresas", produtoId: "rotativo_pj_vol", subproduto: "Aplicação", gerente: "Gerente 3", gerenteNome: "Juliana Prado", carteira: "Carteira Horizonte", linhas: 115.2, cash: 120.5, conquista: 108.4, atividade: true, data: "2025-09-14" },
+  { id: "sd-paulista", diretoria: "DR 02", diretoriaNome: "Sudeste", gerenciaRegional: "GR 03", regional: "Regional São Paulo", gerenteGestao: "GG 03", agenciaCodigo: "Ag 1004", agencia: "Agência 1004 • Avenida Paulista", segmento: "Empresas", produtoId: "rotativo_pj_qtd", subproduto: "Resgate", gerente: "Gerente 3", gerenteNome: "Juliana Prado", carteira: "Carteira Paulista", linhas: 104.8, cash: 99.1, conquista: 101.3, atividade: true, data: "2025-09-06" },
+  { id: "sd-bandeirantes", diretoria: "DR 02", diretoriaNome: "Sudeste", gerenciaRegional: "GR 03", regional: "Regional São Paulo", gerenteGestao: "GG 03", agenciaCodigo: "Ag 1004", agencia: "Agência 1004 • Avenida Paulista", segmento: "Negócios", produtoId: "consorcios", subproduto: "Parcelado", gerente: "Gerente 4", gerenteNome: "Bruno Garcia", carteira: "Carteira Bandeirantes", linhas: 92.7, cash: 88.6, conquista: 94.2, atividade: true, data: "2025-09-10" },
+  { id: "sd-capital", diretoria: "DR 02", diretoriaNome: "Sudeste", gerenciaRegional: "GR 03", regional: "Regional São Paulo", gerenteGestao: "GG 03", agenciaCodigo: "Ag 1004", agencia: "Agência 1004 • Avenida Paulista", segmento: "Negócios", produtoId: "cartoes", subproduto: "À vista", gerente: "Gerente 4", gerenteNome: "Bruno Garcia", carteira: "Carteira Capital", linhas: 105.6, cash: 102.4, conquista: 100.2, atividade: true, data: "2025-09-18" },
+  { id: "sc-curitiba", diretoria: "DR 03", diretoriaNome: "Sul & Centro-Oeste", gerenciaRegional: "GR 04", regional: "Regional Curitiba", gerenteGestao: "GG 02", agenciaCodigo: "Ag 1003", agencia: "Agência 1003 • Curitiba Batel", segmento: "MEI", produtoId: "seguros", subproduto: "Aplicação", gerente: "Gerente 5", gerenteNome: "Carla Menezes", carteira: "Carteira Curitiba", linhas: 109.6, cash: 101.2, conquista: 98.5, atividade: true, data: "2025-09-11" },
+  { id: "sc-litoral", diretoria: "DR 03", diretoriaNome: "Sul & Centro-Oeste", gerenciaRegional: "GR 04", regional: "Regional Curitiba", gerenteGestao: "GG 02", agenciaCodigo: "Ag 1003", agencia: "Agência 1003 • Curitiba Batel", segmento: "MEI", produtoId: "bradesco_expresso", subproduto: "Resgate", gerente: "Gerente 5", gerenteNome: "Carla Menezes", carteira: "Carteira Litoral", linhas: 95.4, cash: 90.1, conquista: 92.8, atividade: true, data: "2025-09-07" },
+  { id: "sc-vale", diretoria: "DR 03", diretoriaNome: "Sul & Centro-Oeste", gerenciaRegional: "GR 04", regional: "Regional Curitiba", gerenteGestao: "GG 02", agenciaCodigo: "Ag 1003", agencia: "Agência 1003 • Curitiba Batel", segmento: "MEI", produtoId: "rec_credito", subproduto: "À vista", gerente: "Gerente 5", gerenteNome: "Carla Menezes", carteira: "Carteira Vale", linhas: 120.2, cash: 115.6, conquista: 110.4, atividade: true, data: "2025-09-17" }
+];
+
+CAMPAIGN_UNIT_DATA.forEach(unit => {
+  const meta = PRODUCT_INDEX.get(unit.produtoId);
+  if (!unit.produtoNome) unit.produtoNome = meta?.name || unit.produto || unit.produtoId || "Produto";
+  if (!unit.gerenteGestaoNome) {
+    const numeric = (unit.gerenteGestao || "").replace(/[^0-9]/g, "");
+    unit.gerenteGestaoNome = numeric ? `Gerente geral ${numeric}` : "Gerente geral";
+  }
+});
+const CAMPAIGN_SPRINTS = [
+  {
+    id: "sprint-pj-2025",
+    label: "Sprint PJ 2025",
+    cycle: "Sprint PJ • Setembro 2025",
+    period: { start: "2025-09-01", end: "2025-09-20" },
+    note: "Projete cenários e acompanhe apenas as unidades visíveis nos filtros atuais.",
+    headStats: [
+      { label: "Meta mínima", value: "100 pts" },
+      { label: "Indicador mínimo", value: "90%" },
+      { label: "Teto considerado", value: "150%" }
+    ],
+    summary: [
+      { id: "equipes", label: "Equipes elegíveis", value: CAMPAIGN_UNIT_DATA.length, total: CAMPAIGN_UNIT_DATA.length },
+      { id: "media", label: "Pontuação média", value: 0, unit: "pts" },
+      { id: "recorde", label: "Maior pontuação", value: 0, unit: "pts", complement: "" },
+      { id: "atualizacao", label: "Atualização", text: "20/09/2025 08:30" }
+    ],
+    team: {
+      minThreshold: 90,
+      superThreshold: 120,
+      cap: 150,
+      eligibilityMinimum: 100,
+      defaultPreset: "meta",
+      indicators: [
+        { id: "linhas", label: "Linhas governamentais", short: "Linhas", weight: 40, hint: "Operações direcionadas, BB Giro e BNDES.", default: 100 },
+        { id: "cash", label: "Cash (TPV)", short: "Cash", weight: 30, hint: "Centralização de caixa e TPV eletrônico.", default: 100 },
+        { id: "conquista", label: "Conquista cliente PJ", short: "Conquista", weight: 30, hint: "Abertura de contas e ativação digital.", default: 100 }
+      ],
+      presets: [
+        { id: "minimo", label: "Mínimo obrigatório (90%)", values: { linhas: 90, cash: 90, conquista: 90 } },
+        { id: "meta", label: "Meta do sprint (100%)", values: { linhas: 100, cash: 100, conquista: 100 } },
+        { id: "stretch", label: "Meta esticada (120%)", values: { linhas: 120, cash: 120, conquista: 120 } }
+      ]
+    },
+    individual: {
+      profiles: [
+        {
+          id: "negocios",
+          label: "Negócios",
+          description: "Carteiras MPE com foco em relacionamento consultivo.",
+          minThreshold: 90,
+          superThreshold: 120,
+          cap: 150,
+          eligibilityMinimum: 100,
+          defaultPreset: "meta",
+          indicators: [
+            { id: "linhas", label: "Linhas governamentais", short: "Linhas", weight: 40, default: 100 },
+            { id: "cash", label: "Cash (TPV)", short: "Cash", weight: 30, default: 100 },
+            { id: "conquista", label: "Conquista cliente PJ", short: "Conquista", weight: 30, default: 100 }
+          ],
+          presets: [
+            { id: "minimo", label: "90% em todos", values: { linhas: 90, cash: 90, conquista: 90 } },
+            { id: "meta", label: "Meta (100%)", values: { linhas: 100, cash: 100, conquista: 100 } },
+            { id: "destaque", label: "Stretch (120%)", values: { linhas: 120, cash: 120, conquista: 120 } }
+          ],
+          scenarios: [
+            { id: "full", label: "100% em todas as linhas", values: { linhas: 100, cash: 100, conquista: 100 }, note: "Parabéns" },
+            { id: "linhas120", label: "Linhas 120%, Cash 100%, Conquista 90%", values: { linhas: 120, cash: 100, conquista: 90 }, note: "Elegível" },
+            { id: "cash115", label: "Linhas 95%, Cash 115%, Conquista 130%", values: { linhas: 95, cash: 115, conquista: 130 }, note: "Elegível" },
+            { id: "ajuste", label: "Linhas 85%, Cash 80%, Conquista 110%", values: { linhas: 85, cash: 80, conquista: 110 }, note: "Ajustar" }
+          ]
+        },
+        {
+          id: "empresas",
+          label: "Empresas",
+          description: "Grandes empresas e governo com foco em volume.",
+          minThreshold: 90,
+          superThreshold: 120,
+          cap: 150,
+          eligibilityMinimum: 100,
+          defaultPreset: "meta",
+          indicators: [
+            { id: "linhas", label: "Linhas governamentais", short: "Linhas", weight: 45, default: 100 },
+            { id: "cash", label: "Cash (TPV)", short: "Cash", weight: 35, default: 100 },
+            { id: "conquista", label: "Conquista cliente PJ", short: "Conquista", weight: 20, default: 100 }
+          ],
+          presets: [
+            { id: "minimo", label: "90% em todos", values: { linhas: 90, cash: 90, conquista: 90 } },
+            { id: "meta", label: "Meta (100%)", values: { linhas: 100, cash: 100, conquista: 100 } },
+            { id: "stretch", label: "Stretch (120%)", values: { linhas: 120, cash: 120, conquista: 120 } }
+          ],
+          scenarios: [
+            { id: "volume", label: "Linhas 130%, Cash 115%, Conquista 95%", values: { linhas: 130, cash: 115, conquista: 95 }, note: "Parabéns" },
+            { id: "equilibrio", label: "Linhas 110%, Cash 105%, Conquista 100%", values: { linhas: 110, cash: 105, conquista: 100 }, note: "Elegível" },
+            { id: "alerta", label: "Linhas 92%, Cash 88%, Conquista 96%", values: { linhas: 92, cash: 88, conquista: 96 }, note: "Ajustar" },
+            { id: "critico", label: "Linhas 80%, Cash 78%, Conquista 85%", values: { linhas: 80, cash: 78, conquista: 85 }, note: "Não elegível" }
+          ]
+        }
+      ]
+    },
+    units: CAMPAIGN_UNIT_DATA
+  }
+];
+
+const CAMPAIGN_LEVEL_META = {
+  diretoria:     { groupField: "diretoria", displayField: "diretoriaNome", singular: "Diretoria", plural: "diretorias" },
+  regional:      { groupField: "gerenciaRegional", displayField: "regional", singular: "Regional", plural: "regionais" },
+  agencia:       { groupField: "agenciaCodigo", displayField: "agencia", singular: "Agência", plural: "agências" },
+  gerenteGestao: { groupField: "gerenteGestao", displayField: "gerenteGestaoNome", singular: "Gerente geral", plural: "gerentes gerais" },
+  gerente:       { groupField: "gerente", displayField: "gerenteNome", singular: "Gerente", plural: "gerentes" },
+  produto:       { groupField: "produtoId", displayField: "produtoNome", singular: "Produto", plural: "produtos" },
+  carteira:      { groupField: "carteira", displayField: "carteira", singular: "Carteira", plural: "carteiras" }
+};
+
+function determineCampaignDisplayLevel(filters = getFilterValues()) {
+  if (filters.gerente && filters.gerente !== "Todos") {
+    return { level: "produto", meta: CAMPAIGN_LEVEL_META.produto };
+  }
+  if (filters.ggestao && filters.ggestao !== "Todos") {
+    return { level: "gerente", meta: CAMPAIGN_LEVEL_META.gerente };
+  }
+  if (filters.agencia && filters.agencia !== "Todas") {
+    return { level: "gerenteGestao", meta: CAMPAIGN_LEVEL_META.gerenteGestao };
+  }
+  if (filters.gerencia && filters.gerencia !== "Todas") {
+    return { level: "agencia", meta: CAMPAIGN_LEVEL_META.agencia };
+  }
+  if (filters.diretoria && filters.diretoria !== "Todas") {
+    return { level: "regional", meta: CAMPAIGN_LEVEL_META.regional };
+  }
+  return { level: "diretoria", meta: CAMPAIGN_LEVEL_META.diretoria };
+}
+
+function filterCampaignUnits(sprint, filters = getFilterValues()) {
+  const units = sprint?.units || [];
+  const startISO = state.period.start;
+  const endISO = state.period.end;
+  return units.filter(unit => {
+    const okSegmento = (!filters.segmento || filters.segmento === "Todos" || unit.segmento === filters.segmento);
+    const okDiretoria = (!filters.diretoria || filters.diretoria === "Todas" || unit.diretoria === filters.diretoria);
+    const okGerencia = (!filters.gerencia || filters.gerencia === "Todas" || unit.gerenciaRegional === filters.gerencia);
+    const okAgencia = (!filters.agencia || filters.agencia === "Todas" || unit.agenciaCodigo === filters.agencia);
+    const okGG = (!filters.ggestao || filters.ggestao === "Todos" || unit.gerenteGestao === filters.ggestao);
+    const okGerente = (!filters.gerente || filters.gerente === "Todos" || unit.gerente === filters.gerente);
+    const okProduto = (!filters.produtoId || filters.produtoId === "Todas" || unit.produtoId === filters.produtoId);
+    const okSub = (!filters.subproduto || unit.subproduto === filters.subproduto);
+    const okDate = (!startISO || unit.data >= startISO) && (!endISO || unit.data <= endISO);
+    return okSegmento && okDiretoria && okGerencia && okAgencia && okGG && okGerente && okProduto && okSub && okDate;
+  });
+}
+
+function campaignStatusMatches(score, statusFilter = "todos") {
+  if (statusFilter === "todos") return true;
+  const elegivel = score.finalStatus === "Parabéns" || score.finalStatus === "Elegível";
+  return statusFilter === "atingidos" ? elegivel : !elegivel;
+}
+
+function aggregateCampaignUnitResults(unitResults, level, teamConfig) {
+  const meta = CAMPAIGN_LEVEL_META[level] || CAMPAIGN_LEVEL_META.diretoria;
+  const field = meta.groupField;
+  const nameField = meta.displayField || field;
+  const buckets = new Map();
+
+  unitResults.forEach(({ unit }) => {
+    const key = unit[field] || unit[nameField] || "—";
+    const bucket = buckets.get(key) || {
+      key,
+      name: unit[nameField] || key,
+      linhas: 0,
+      cash: 0,
+      conquista: 0,
+      count: 0,
+      atividadeHits: 0
+    };
+    bucket.name = unit[nameField] || key;
+    bucket.linhas += toNumber(unit.linhas);
+    bucket.cash += toNumber(unit.cash);
+    bucket.conquista += toNumber(unit.conquista);
+    bucket.count += 1;
+    bucket.atividadeHits += unit.atividade ? 1 : 0;
+    buckets.set(key, bucket);
+  });
+
+  return [...buckets.values()].map(bucket => {
+    const linhas = bucket.count ? bucket.linhas / bucket.count : 0;
+    const cash = bucket.count ? bucket.cash / bucket.count : 0;
+    const conquista = bucket.count ? bucket.conquista / bucket.count : 0;
+    const result = computeCampaignScore(teamConfig, { linhas, cash, conquista });
+    const atividade = bucket.atividadeHits >= Math.ceil(bucket.count / 2);
+    return {
+      key: bucket.key,
+      name: bucket.name,
+      linhas,
+      cash,
+      conquista,
+      atividade,
+      finalStatus: result.finalStatus,
+      finalClass: result.finalClass,
+      totalPoints: result.totalPoints,
+      result
+    };
+  });
+}
+
+function summarizeCampaignUnitResults(unitResults) {
+  const total = unitResults.length;
+  if (!total) {
+    return { total: 0, elegiveis: 0, media: 0, recorde: 0, destaque: "" };
+  }
+
+  let soma = 0;
+  let elegiveis = 0;
+  let recorde = -Infinity;
+  let destaque = "";
+
+  unitResults.forEach(({ unit, score }) => {
+    soma += score.totalPoints;
+    if (score.finalStatus === "Parabéns" || score.finalStatus === "Elegível") elegiveis += 1;
+    if (score.totalPoints > recorde) {
+      recorde = score.totalPoints;
+      destaque = unit.regional || unit.agencia || unit.gerenteNome || unit.carteira || unit.diretoriaNome || "";
+    }
+  });
+
+  return {
+    total,
+    elegiveis,
+    media: soma / total,
+    recorde: recorde > 0 ? recorde : 0,
+    destaque
+  };
+}
+
+function buildCampaignRankingContext(sprint) {
+  if (!sprint) {
+    const levelInfo = determineCampaignDisplayLevel();
+    return { unitResults: [], aggregated: [], levelInfo };
+  }
+
+  const filters = getFilterValues();
+  const filteredUnits = filterCampaignUnits(sprint, filters);
+  const unitResults = filteredUnits.map(unit => ({
+    unit,
+    score: computeCampaignScore(sprint.team, {
+      linhas: unit.linhas,
+      cash: unit.cash,
+      conquista: unit.conquista
+    })
+  })).filter(({ score }) => campaignStatusMatches(score, filters.status || "todos"));
+
+  const levelInfo = determineCampaignDisplayLevel(filters);
+  const aggregated = aggregateCampaignUnitResults(unitResults, levelInfo.level, sprint.team);
+
+  return { unitResults, aggregated, levelInfo };
+}
+
 /* ===== Datas (UTC) ===== */
 function firstDayOfMonthISO(d=new Date()){ return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,"0")}-01`; }
 function todayISO(d=new Date()){ return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,"0")}-${String(d.getDate()).padStart(2,"0")}`; }
@@ -113,17 +455,86 @@ function businessDaysRemainingFromToday(startISO,endISO){
 }
 
 /* ===== Helpers de métrica ===== */
+const toNumber = (value) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+};
+
+const escapeHTML = (value = "") => String(value).replace(/[&<>"']/g, (ch) => ({
+  "&":"&amp;",
+  "<":"&lt;",
+  ">":"&gt;",
+  '"':"&quot;",
+  "'":"&#39;"
+}[ch]));
+
+function formatNumberWithSuffix(value, { currency = false } = {}) {
+  const n = toNumber(value);
+  if (!Number.isFinite(n)) return currency ? fmtBRL.format(0) : fmtINT.format(0);
+  const abs = Math.abs(n);
+  if (abs < 1000) {
+    return currency ? fmtBRL.format(n) : fmtINT.format(Math.round(n));
+  }
+  const rule = SUFFIX_RULES.find(r => abs >= r.value);
+  if (!rule) {
+    return currency ? fmtBRL.format(n) : fmtINT.format(Math.round(n));
+  }
+  const absScaled = abs / rule.value;
+  const nearInteger = Math.abs(absScaled - Math.round(absScaled)) < 0.05;
+  let digits;
+  if (absScaled >= 100) digits = 0;
+  else if (absScaled >= 10) digits = nearInteger ? 0 : 1;
+  else digits = nearInteger ? 0 : 1;
+  const numberFmt = new Intl.NumberFormat("pt-BR", { minimumFractionDigits: digits, maximumFractionDigits: digits });
+  const formatted = numberFmt.format(absScaled);
+  const isSingular = Math.abs(absScaled - 1) < 0.05;
+  const label = isSingular ? rule.singular : rule.plural;
+  if (currency) {
+    const sign = n < 0 ? "-" : "";
+    return `${sign}${CURRENCY_SYMBOL}${CURRENCY_LITERAL}${formatted} ${label}`;
+  }
+  const sign = n < 0 ? "-" : "";
+  return `${sign}${formatted} ${label}`;
+}
+
+function formatIntReadable(value){
+  return formatNumberWithSuffix(value, { currency: false });
+}
+function formatBRLReadable(value){
+  return formatNumberWithSuffix(value, { currency: true });
+}
+
+function formatMetricFull(metric, value){
+  const n = Math.round(toNumber(value));
+  if(metric === "perc") return `${toNumber(value).toFixed(1)}%`;
+  if(metric === "qtd")  return fmtINT.format(n);
+  return fmtBRL.format(n);
+}
 function formatByMetric(metric, value){
-  if(metric === "perc") return `${Number(value).toFixed(1)}%`;
-  if(metric === "qtd")  return fmtINT.format(Math.round(value));
-  return fmtBRL.format(Math.round(value));
+  if(metric === "perc") return `${toNumber(value).toFixed(1)}%`;
+  if(metric === "qtd")  return formatIntReadable(value);
+  return formatBRLReadable(value);
+}
+function formatCompactBRL(value){
+  return formatNumberWithSuffix(value, { currency: true });
 }
 function makeRandomForMetric(metric){
-  if(metric === "perc"){ const meta=100; const realizado=Math.round(45+Math.random()*75); return { meta, realizado }; }
-  if(metric === "qtd"){ const meta=Math.round(1_000+Math.random()*19_000); const realizado=Math.round(meta*(0.75+Math.random()*0.6)); return { meta, realizado }; }
-  const meta=Math.round(4_000_000+Math.random()*16_000_000);
-  const realizado=Math.round(meta*(0.75+Math.random()*0.6));
-  return { meta, realizado };
+  if(metric === "perc"){
+    const meta = 100;
+    const realizado = Math.round(45 + Math.random()*75);
+    const variavelMeta = Math.round(160_000 + Math.random()*180_000);
+    return { meta, realizado, variavelMeta };
+  }
+  if(metric === "qtd"){
+    const meta = Math.round(1_000 + Math.random()*19_000);
+    const realizado = Math.round(meta * (0.75 + Math.random()*0.6));
+    const variavelMeta = Math.round(150_000 + Math.random()*220_000);
+    return { meta, realizado, variavelMeta };
+  }
+  const meta = Math.round(4_000_000 + Math.random()*16_000_000);
+  const realizado = Math.round(meta * (0.75 + Math.random()*0.6));
+  const variavelMeta = Math.round(320_000 + Math.random()*420_000);
+  return { meta, realizado, variavelMeta };
 }
 
 /* ===== API / MOCK ===== */
@@ -135,16 +546,50 @@ async function apiGet(path, params){
 async function getData(){
   const period = state.period || { start:firstDayOfMonthISO(), end: todayISO() };
 
+  const startDt = dateUTCFromISO(period.start);
+  const endDt = dateUTCFromISO(period.end);
+  let startRef = startDt;
+  let endRef = endDt;
+  if (startRef && endRef && startRef > endRef) [startRef, endRef] = [endRef, startRef];
+  const defaultISO = period.end || period.start || todayISO();
+  const randomPeriodISO = () => {
+    if (!startRef || !endRef) return defaultISO;
+    const spanDays = Math.max(0, Math.round((endRef - startRef) / (24 * 60 * 60 * 1000)));
+    const offset = spanDays > 0 ? Math.floor(Math.random() * (spanDays + 1)) : 0;
+    const dt = new Date(startRef.getTime());
+    dt.setUTCDate(dt.getUTCDate() + offset);
+    return isoFromUTCDate(dt);
+  };
+
   // MOCK
-  const hoje = new Date();
   const sections = CARD_SECTIONS_DEF.map(sec=>{
     const items = sec.items.map(it=>{
-      const { meta, realizado } = makeRandomForMetric(it.metric);
-      const ating = it.metric==="perc" ? (realizado/100) : (meta? realizado/meta : 0);
-      return { ...it, meta, realizado, ating, atingido: ating>=1, ultimaAtualizacao: hoje.toLocaleDateString("pt-BR") };
+      const { meta, realizado, variavelMeta } = makeRandomForMetric(it.metric);
+      const ating = it.metric==="perc" ? (realizado/100) : (meta ? realizado/meta : 0);
+      const variavelReal = Math.max(0, Math.round((variavelMeta || 0) * ating));
+      const atingVariavel = variavelMeta ? (variavelReal / variavelMeta) : ating;
+      return {
+        ...it,
+        meta,
+        realizado,
+        variavelMeta,
+        variavelReal,
+        ating,
+        atingVariavel,
+        atingido: ating>=1,
+        ultimaAtualizacao: formatBRDate(defaultISO)
+      };
     });
     return { id:sec.id, label:sec.label, items };
   });
+
+  const totalsVar = sections.reduce((acc, sec)=>{
+    sec.items.forEach(item => {
+      acc.possivel += item.variavelMeta || 0;
+      acc.atingido += item.variavelReal || 0;
+    });
+    return acc;
+  }, { possivel:0, atingido:0 });
 
   const allItems = sections.flatMap(s => s.items);
   const indicadoresTotal = allItems.length;
@@ -152,11 +597,16 @@ async function getData(){
   const pontosPossiveis = allItems.reduce((acc,i)=> acc + (i.peso||0), 0);
   const pontosAtingidos = allItems.filter(i=>i.atingido).reduce((acc,i)=> acc + (i.peso||0), 0);
 
-  const dres  = ["DR 01","DR 02","DR 03"];
-  const grs   = ["GR 01","GR 02","GR 03","GR 04"];
   const segs  = ["Empresas","Negócios","MEI"];
   const prodIds = [...PRODUCT_INDEX.keys()];
   const famsMacro = ["Crédito","Investimentos","Seguros","Consórcios","Previdência","Cartão de crédito"];
+  const canaisVenda = ["Agência física","Digital","Correspondente","APP Empresas"];
+  const tiposVenda = ["Venda consultiva","Venda direta","Cross-sell","Pós-venda"];
+  const modalidadesVenda = ["À vista","Parcelado"];
+  const agenciasPorGerencia = RANKING_GERENCIAS.reduce((map, ger) => {
+    map.set(ger.id, RANKING_AGENCIAS.filter(ag => ag.gerencia === ger.id));
+    return map;
+  }, new Map());
 
   const ranking = Array.from({length:140}, (_,i)=>{
     const produtoId = prodIds[i % prodIds.length];
@@ -165,28 +615,49 @@ async function getData(){
     const subproduto = subps[Math.floor(Math.random()*subps.length)];
     const produtoNome = metaProd?.name || produtoId;
 
+    const gerMeta = RANKING_GERENCIAS[i % RANKING_GERENCIAS.length];
+    const dirMeta = RANKING_DIRECTORIAS.find(d => d.id === gerMeta.diretoria) || RANKING_DIRECTORIAS[0];
+    const agPool = agenciasPorGerencia.get(gerMeta.id) || RANKING_AGENCIAS;
+    const agenciaMeta = agPool[i % agPool.length] || RANKING_AGENCIAS[i % RANKING_AGENCIAS.length];
+    const gerenteMeta = RANKING_GERENTES[i % RANKING_GERENTES.length];
+    const gerenteGestao = `GG ${String(1 + (i%3)).padStart(2,"0")}`;
+    const gerenteGestaoNome = `Gestão ${String(1 + (i%6)).padStart(2,"0")}`;
+
     const meta_mens = Math.round(2_000_000 + Math.random()*18_000_000);
     const real_mens = Math.round(meta_mens*(0.75+Math.random()*0.6));
     const fator = 1.2 + Math.random()*1.2;
     const meta_acum = Math.round(meta_mens * fator);
     const real_acum = Math.round(real_mens * fator);
 
+    const canalVenda = canaisVenda[Math.floor(Math.random()*canaisVenda.length)];
+    const tipoVenda = tiposVenda[Math.floor(Math.random()*tiposVenda.length)];
+    const modalidadePagamento = modalidadesVenda[Math.floor(Math.random()*modalidadesVenda.length)];
+
     return {
-      diretoria: dres[i % dres.length],
-      gerenciaRegional: grs[i % grs.length],
-      gerenteGestao: `GG ${String(1 + (i%3)).padStart(2,"0")}`,
+      diretoria: dirMeta.id,
+      diretoriaNome: dirMeta.nome,
+      gerenciaRegional: gerMeta.id,
+      gerenciaNome: gerMeta.nome,
+      regional: gerMeta.nome,
+      gerenteGestao,
+      gerenteGestaoNome,
       familia: famsMacro[i % famsMacro.length],
       produtoId,
       produto: produtoNome,
       prodOrSub: subproduto || produtoNome,
       subproduto,
-      gerente: `Gerente ${1+(i%16)}`,
-      agencia: `Ag ${1000+i}`,
+      gerente: gerenteMeta.id,
+      gerenteNome: gerenteMeta.nome,
+      agencia: agenciaMeta.id,
+      agenciaNome: agenciaMeta.nome,
       segmento: segs[i % segs.length],
+      canalVenda,
+      tipoVenda,
+      modalidadePagamento,
       realizado: real_mens,
       meta:      meta_mens,
       qtd:       Math.round(50 + Math.random()*1950),
-      data:      todayISO(),
+      data:      randomPeriodISO(),
       real_mens, meta_mens, real_acum, meta_acum
     };
   });
@@ -200,7 +671,10 @@ async function getData(){
       indicadoresPct: indicadoresTotal ? indicadoresAtingidos/indicadoresTotal : 0,
       pontosPossiveis,
       pontosAtingidos,
-      pontosPct: pontosPossiveis ? pontosAtingidos/pontosPossiveis : 0
+      pontosPct: pontosPossiveis ? pontosAtingidos/pontosPossiveis : 0,
+      varPossivel: totalsVar.possivel,
+      varAtingido: totalsVar.atingido,
+      varPct: totalsVar.possivel ? (totalsVar.atingido / totalsVar.possivel) : 0
     },
     ranking,
     period
@@ -281,6 +755,7 @@ function ensureSidebar(){
     document.querySelector(".topbar__left")?.prepend(btnTop);
   }
   btnTop.type = "button";
+  btnTop.setAttribute("aria-expanded", "false");
 
   const btnSB  = document.getElementById("sb-btn");
 
@@ -302,34 +777,30 @@ function ensureSidebar(){
     try{ localStorage.setItem(LS_KEY, sb.classList.contains("sidebar--collapsed") ? "1" : "0"); }catch(_){}
   }
   function openMobile(){
-    // guarda o estado original de colapso do desktop
-    sb.dataset.restoreCollapsed = sb.classList.contains("sidebar--collapsed") ? "1" : "0";
-    sb.classList.remove("sidebar--collapsed");   // <- garante que os textos apareçam
-    sb.classList.add("sidebar--open");
-    document.getElementById("sidebar-backdrop")?.classList.add("is-show");
-    document.documentElement.classList.add("drawer-open");
-    btnSB?.setAttribute("aria-expanded","true");
+    if (!isMobile()) return;
+    openMobileFilters();
   }
   function closeMobile(){
-    sb.classList.remove("sidebar--open");
-    document.getElementById("sidebar-backdrop")?.classList.remove("is-show");
-    document.documentElement.classList.remove("drawer-open");
-    btnSB?.setAttribute("aria-expanded","false");
-
-    // restaura o estado de colapso que o usuário tinha no desktop
-    if (sb.dataset.restoreCollapsed === "1") {
-      sb.classList.add("sidebar--collapsed");
-    }
+    if (!isMobile()) return;
+    closeMobileFilters();
   }
   function toggleMobile(){
-    if(sb.classList.contains("sidebar--open")) closeMobile(); else openMobile();
+    if (!isMobile()) return;
+    const isOpen = document.body.classList.contains("filters-open");
+    if (isOpen) {
+      closeMobileFilters();
+    } else {
+      openMobileFilters();
+    }
+    btnTop?.setAttribute("aria-expanded", String(!isOpen));
+    btnSB?.setAttribute("aria-expanded", String(!isOpen));
   }
 
   // listeners
   btnSB?.addEventListener("click", ()=> isMobile() ? toggleMobile() : toggleDesktop());
   btnTop?.addEventListener("click", ()=> isMobile() ? toggleMobile() : toggleDesktop());
-  backdrop.addEventListener("click", closeMobile);
-  window.addEventListener("resize", ()=> { if(!isMobile()) closeMobile(); });
+  backdrop.addEventListener("click", ()=> { if (isMobile()) closeMobileFilters(); });
+  window.addEventListener("resize", ()=> { if(!isMobile()) closeMobileFilters(); });
 
   // navegação “fake”
   document.querySelectorAll(".sidebar__link").forEach(a=>{
@@ -338,6 +809,12 @@ function ensureSidebar(){
       document.querySelectorAll(".sidebar__link").forEach(x=>x.classList.remove("is-active"));
       a.classList.add("is-active");
       if(isMobile()) closeMobile();
+      const route = a.dataset.route;
+      if (route === "campanhas") {
+        if (state.activeView !== "campanhas") switchView("campanhas");
+      } else if (route === "pobj") {
+        if (state.activeView !== "cards") switchView("cards");
+      }
     });
   });
 }
@@ -351,16 +828,31 @@ const state = {
   tableView:"diretoria",
   tableRendered:false,
   isAnimating:false,
-  period: { start:firstDayOfMonthISO(), end: todayISO() },
+  period: { start:"2025-09-01", end:"2025-09-20" },
   datePopover:null,
   compact:false,
+  contractIndex:[],
+  lastNonContractView:"diretoria",
 
   // ranking
   rk:{ mode:"mensal", level:"agencia" },
 
   // busca por contrato (usa o input #busca)
-  tableSearchTerm:""
+  tableSearchTerm:"",
+
+  campanhas:{
+    sprintId: CAMPAIGN_SPRINTS[0]?.id || null,
+    teamValues:{},
+    teamPreset:{},
+    individualProfile: CAMPAIGN_SPRINTS[0]?.individual?.profiles?.[0]?.id || null,
+    individualValues:{},
+    individualPreset:{}
+  }
 };
+
+const contractSuggestState = { items: [], highlight: -1, open: false, term: "", pending: null };
+let contractSuggestDocBound = false;
+let contractSuggestPanelBound = false;
 
 /* ===== Utils UI ===== */
 function injectStyles(){
@@ -374,76 +866,39 @@ function injectStyles(){
   .view-panel.is-enter-active{ opacity:1; transform:translateY(0); }
   .hidden{ display:none; }
 
-  /* ===== KPI topo: versão mais “grossa” ===== */
+  /* ===== KPI topo: versão ajustada ===== */
   #kpi-summary.kpi-summary{
     display:flex !important;
     flex-wrap:wrap;
-    gap:8px;
-    margin:6px 0 8px;
-    align-items:stretch;
+    gap:18px;
+    margin:8px 0 14px;
+    align-items:flex-start;
   }
-  #kpi-summary .kpi-pill{ padding:10px 12px; gap:10px; }
-  #kpi-summary .kpi-icon{ width:28px; height:28px; }
-  #kpi-summary .kpi-strip__label{ font-size:13px; }
-  #kpi-summary .kpi-stat{ font-size:12px; }
-
-  #kpi-summary .hitbar__track{ height:12px; border-width:1.5px; }
-  #kpi-summary .hitbar strong{ font-size:12px; min-width:42px; max-width:60px; }
-
   #kpi-summary .kpi-pill{
-    flex:1 1 0;
-    min-width:188px;
-    padding:6px 8px;
-    display:flex; align-items:center; gap:8px;
-    overflow:hidden; min-width:0;
+    flex:1 1 320px;
+    min-width:280px;
+    padding:24px 26px;
+    gap:14px;
+  }
+  #kpi-summary .kpi-strip__main{ gap:14px; }
+  #kpi-summary .kpi-icon{ width:42px; height:42px; font-size:18px; }
+  #kpi-summary .kpi-strip__label{ font-size:13.5px; max-width:220px; }
+  #kpi-summary .kpi-stat{ font-size:12.5px; }
+
+  #kpi-summary .hitbar{
+    width:100%;
+    gap:12px;
+  }
+  #kpi-summary .hitbar__track{
+    min-width:0;
+    height:9px;
+    border-width:1.5px;
+  }
+  #kpi-summary .hitbar strong{
+    font-size:12.5px;
   }
 
-  .kpi-strip{ display:flex; align-items:center; gap:6px; width:100%; min-width:0; }
-  .kpi-icon{
-    width:22px; height:22px; border-radius:999px;
-    display:grid; place-items:center;
-    background:#eef2ff; color:#1d4ed8;
-    flex:0 0 22px;
-  }
-
-  .kpi-strip__label{
-    font-weight:800; color:#111827;
-    font-size:12px; line-height:1;
-    flex:0 1 78px; min-width:56px; max-width:120px;
-    white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
-  }
-  .kpi-stat{
-    color:#6b7280; font-size:11px; line-height:1;
-    white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
-    flex:0 1 92px; min-width:68px;
-    font-variant-numeric: tabular-nums;
-  }
-  .kpi-stat strong{ color:#111827; }
-
-  .hitbar{
-    display:flex; align-items:center; gap:6px;
-    flex:1 1 160px; margin-left:auto; min-width:0;
-  }
-  .hitbar__track{
-    position:relative; flex:1 1 0; min-width:70px;
-    height:8px; border-radius:999px;
-    background:#eef2ff; border:1px solid #e5e7eb; overflow:hidden;
-  }
-  .hitbar__fill{ position:absolute; left:0; top:0; bottom:0; width:0%; }
-  .hitbar--low  .hitbar__fill{ background:#fecaca; }
-  .hitbar--warn .hitbar__fill{ background:#fed7aa; }
-  .hitbar--ok   .hitbar__fill{ background:#bbf7d0; }
-
-  .hitbar strong{
-    flex:0 1 42px; min-width:36px; max-width:54px;
-    overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
-    text-align:right; font-weight:800; font-size:11px; color:#111827;
-  }
-
-  @media (max-width: 1280px){
-    #kpi-summary .kpi-stat--total{ display:none; }
-  }
-  @media (max-width: 520px){
+  @media (max-width: 720px){
     #kpi-summary .kpi-pill{ min-width:100%; }
   }
 `;
@@ -518,13 +973,13 @@ function wireClearFiltersButton() {
   const btn = $("#btn-limpar");
   if (!btn || btn.dataset.wired === "1") return;
   btn.dataset.wired = "1";
-  btn.addEventListener("click", (ev) => {
+  btn.addEventListener("click", async (ev) => {
     ev.preventDefault();
     btn.disabled = true;
-    try { clearFilters(); } finally { setTimeout(() => (btn.disabled = false), 250); }
+    try { await clearFilters(); } finally { setTimeout(() => (btn.disabled = false), 250); }
   });
 }
-function clearFilters() {
+async function clearFilters() {
   [
     "#f-segmento","#f-diretoria","#f-gerencia","#f-gerente",
     "#f-agencia","#f-ggestao","#f-familia","#f-produto",
@@ -543,11 +998,183 @@ function clearFilters() {
   // limpa busca (contrato) e estado
   state.tableSearchTerm = "";
   if ($("#busca")) $("#busca").value = "";
+  refreshContractSuggestions("");
+  if (state.tableView === "contrato") {
+    state.tableView = "diretoria";
+    state.lastNonContractView = "diretoria";
+    setActiveChip("diretoria");
+  }
 
-  applyFiltersAndRender();
-  if (state._dataset) renderFamilias(state._dataset.sections, state._dataset.summary);
-  renderAppliedFilters();
-  if (state.activeView === "ranking") renderRanking();
+  await withSpinner(async () => {
+    applyFiltersAndRender();
+    if (state._dataset) renderFamilias(state._dataset.sections, state._dataset.summary);
+    renderAppliedFilters();
+    renderCampanhasView();
+    if (state.activeView === "ranking") renderRanking();
+  }, "Limpando filtros…");
+  closeMobileFilters();
+}
+
+function setMobileFiltersState(open) {
+  const card = document.querySelector(".card--filters");
+  if (!card) return;
+  card.classList.toggle("is-mobile-open", open);
+  card.setAttribute("aria-expanded", open ? "true" : "false");
+  document.body.classList.toggle("filters-open", open);
+
+  const hamburger = document.querySelector(".topbar-hamburger");
+  if (hamburger) hamburger.setAttribute("aria-expanded", open ? "true" : "false");
+  const sidebarToggle = document.getElementById("sb-btn");
+  if (sidebarToggle) sidebarToggle.setAttribute("aria-expanded", open ? "true" : "false");
+
+  const backdrop = document.getElementById("filters-backdrop");
+  if (backdrop) {
+    if (open) {
+      backdrop.hidden = false;
+      backdrop.classList.add("is-show");
+    } else {
+      backdrop.classList.remove("is-show");
+      backdrop.hidden = true;
+    }
+  }
+
+  const toggle = document.getElementById("btn-mobile-filtros");
+  if (toggle) toggle.setAttribute("aria-expanded", open ? "true" : "false");
+}
+
+function openMobileFilters(){ setMobileFiltersState(true); }
+function closeMobileFilters(){ setMobileFiltersState(false); }
+
+function setupMobileFilters(){
+  const openBtn = document.getElementById("btn-mobile-filtros");
+  const closeBtn = document.getElementById("btn-fechar-filtros");
+  const backdrop = document.getElementById("filters-backdrop");
+
+  if (openBtn && !openBtn.dataset.bound) {
+    openBtn.dataset.bound = "1";
+    openBtn.addEventListener("click", () => openMobileFilters());
+  }
+  if (closeBtn && !closeBtn.dataset.bound) {
+    closeBtn.dataset.bound = "1";
+    closeBtn.addEventListener("click", () => closeMobileFilters());
+  }
+  if (backdrop && !backdrop.dataset.bound) {
+    backdrop.dataset.bound = "1";
+    backdrop.addEventListener("click", () => closeMobileFilters());
+  }
+
+  if (!setupMobileFilters._escBound) {
+    window.addEventListener("keydown", (ev) => {
+      if (ev.key === "Escape") closeMobileFilters();
+    });
+    setupMobileFilters._escBound = true;
+  }
+}
+
+function initMobileCarousel(){
+  const host = document.getElementById("mobile-carousel");
+  if (!host) return;
+  const slides = Array.from(host.querySelectorAll(".mobile-carousel__slide"));
+  const dots = Array.from(host.querySelectorAll(".mobile-carousel__dot"));
+  const prevBtn = host.querySelector("[data-carousel-prev]");
+  const nextBtn = host.querySelector("[data-carousel-next]");
+  if (slides.length <= 1) {
+    slides.forEach(slide => slide.classList.add("is-active"));
+    dots.forEach(dot => dot.setAttribute("aria-current", "true"));
+    if (prevBtn) prevBtn.hidden = true;
+    if (nextBtn) nextBtn.hidden = true;
+    return;
+  }
+  if (prevBtn) prevBtn.hidden = false;
+  if (nextBtn) nextBtn.hidden = false;
+
+  let current = 0;
+  let timer = null;
+  let pointerStart = null;
+
+  const activate = (idx) => {
+    if (!slides.length) return;
+    const next = (idx + slides.length) % slides.length;
+    slides.forEach((slide, i) => {
+      slide.classList.toggle("is-active", i === next);
+      slide.setAttribute("aria-hidden", i === next ? "false" : "true");
+    });
+    dots.forEach((dot, i) => {
+      dot.setAttribute("aria-current", i === next ? "true" : "false");
+    });
+    current = next;
+  };
+
+  const goTo = (idx) => {
+    stop();
+    activate(idx);
+    start();
+  };
+
+  const start = () => {
+    if (timer) return;
+    timer = setInterval(() => activate(current + 1), 6000);
+  };
+
+  const stop = () => {
+    if (!timer) return;
+    clearInterval(timer);
+    timer = null;
+  };
+
+  dots.forEach((dot, idx) => {
+    if (dot.dataset.bound) return;
+    dot.dataset.bound = "1";
+    dot.addEventListener("click", () => {
+      goTo(idx);
+    });
+  });
+
+  if (prevBtn && !prevBtn.dataset.bound) {
+    prevBtn.dataset.bound = "1";
+    prevBtn.addEventListener("click", () => goTo(current - 1));
+  }
+  if (nextBtn && !nextBtn.dataset.bound) {
+    nextBtn.dataset.bound = "1";
+    nextBtn.addEventListener("click", () => goTo(current + 1));
+  }
+
+  const handlePointerDown = (ev) => {
+    if (ev.pointerType === "mouse" && ev.button !== 0) return;
+    pointerStart = ev.clientX;
+    stop();
+  };
+
+  const handlePointerUp = (ev) => {
+    if (pointerStart === null) return;
+    const delta = ev.clientX - pointerStart;
+    pointerStart = null;
+    if (Math.abs(delta) > 30) {
+      goTo(delta < 0 ? current + 1 : current - 1);
+    } else {
+      start();
+    }
+  };
+
+  const handlePointerCancel = () => {
+    pointerStart = null;
+    start();
+  };
+
+  host.addEventListener("pointerdown", handlePointerDown);
+  host.addEventListener("pointerup", handlePointerUp);
+  host.addEventListener("pointercancel", handlePointerCancel);
+  host.addEventListener("pointerleave", () => {
+    pointerStart = null;
+  });
+
+  host.addEventListener("pointerenter", stop, { passive: true });
+  host.addEventListener("pointerleave", start, { passive: true });
+  host.addEventListener("focusin", stop);
+  host.addEventListener("focusout", start);
+
+  activate(0);
+  start();
 }
 
 /* ===== Avançado ===== */
@@ -567,10 +1194,14 @@ function ensureStatusFilterInAdvanced() {
         <option value="nao">Não atingidos</option>
       </select>`;
     host.appendChild(wrap);
-    $("#f-status-kpi").addEventListener("change", () => {
-      if (state._dataset) renderFamilias(state._dataset.sections, state._dataset.summary);
-      applyFiltersAndRender();
-      renderAppliedFilters();
+    $("#f-status-kpi").addEventListener("change", async () => {
+      await withSpinner(async () => {
+        if (state._dataset) renderFamilias(state._dataset.sections, state._dataset.summary);
+        applyFiltersAndRender();
+        renderAppliedFilters();
+        renderCampanhasView();
+        if (state.activeView === "ranking") renderRanking();
+      }, "Atualizando filtros…");
     });
   }
 
@@ -603,6 +1234,9 @@ function ensureChipBarAndToolbar() {
     if (v.id === state.tableView) chip.classList.add("is-active");
     chip.addEventListener("click", () => {
       if (state.tableView === v.id) return;
+      if (v.id === "contrato" && state.tableView !== "contrato") {
+        state.lastNonContractView = state.tableView;
+      }
       state.tableView = v.id;
       setActiveChip(v.id);
       renderTreeTable();
@@ -629,6 +1263,9 @@ function ensureChipBarAndToolbar() {
 }
 function setActiveChip(viewId) {
   $$("#chipbar .chip").forEach(c => c.classList.toggle("is-active", c.dataset.view === viewId));
+  if (viewId && viewId !== "contrato") {
+    state.lastNonContractView = viewId;
+  }
 }
 
 /* ===== “Filtros aplicados” ===== */
@@ -644,12 +1281,15 @@ function renderAppliedFilters() {
       <span class="k">${k}</span>
       <span class="v">${v}</span>
       <button type="button" title="Limpar" class="applied-x" aria-label="Remover ${k}"><i class="ti ti-x"></i></button>`;
-    chip.querySelector("button").addEventListener("click", () => {
-      resetFn?.();
-      applyFiltersAndRender();
-      renderAppliedFilters();
-      if (state._dataset) renderFamilias(state._dataset.sections, state._dataset.summary);
-      if (state.activeView === "ranking") renderRanking();
+    chip.querySelector("button").addEventListener("click", async () => {
+      await withSpinner(async () => {
+        resetFn?.();
+        applyFiltersAndRender();
+        renderAppliedFilters();
+        if (state._dataset) renderFamilias(state._dataset.sections, state._dataset.summary);
+        renderCampanhasView();
+        if (state.activeView === "ranking") renderRanking();
+      }, "Atualizando filtros…");
     });
     items.push(chip);
   };
@@ -657,11 +1297,23 @@ function renderAppliedFilters() {
   bar.innerHTML = "";
 
   if (vals.segmento && vals.segmento !== "Todos") push("Segmento", vals.segmento, () => $("#f-segmento").selectedIndex = 0);
-  if (vals.diretoria && vals.diretoria !== "Todas") push("Diretoria", vals.diretoria, () => $("#f-diretoria").selectedIndex = 0);
-  if (vals.gerencia && vals.gerencia !== "Todas") push("Gerência", vals.gerencia, () => $("#f-gerencia").selectedIndex = 0);
-  if (vals.agencia && vals.agencia !== "Todas") push("Agência", vals.agencia, () => $("#f-agencia").selectedIndex = 0);
+  if (vals.diretoria && vals.diretoria !== "Todas") {
+    const label = $("#f-diretoria")?.selectedOptions?.[0]?.text || vals.diretoria;
+    push("Diretoria", label, () => $("#f-diretoria").selectedIndex = 0);
+  }
+  if (vals.gerencia && vals.gerencia !== "Todas") {
+    const label = $("#f-gerencia")?.selectedOptions?.[0]?.text || vals.gerencia;
+    push("Gerência", label, () => $("#f-gerencia").selectedIndex = 0);
+  }
+  if (vals.agencia && vals.agencia !== "Todas") {
+    const label = $("#f-agencia")?.selectedOptions?.[0]?.text || vals.agencia;
+    push("Agência", label, () => $("#f-agencia").selectedIndex = 0);
+  }
   if (vals.ggestao && vals.ggestao !== "Todos") push("Gerente de gestão", vals.ggestao, () => $("#f-ggestao").selectedIndex = 0);
-  if (vals.gerente && vals.gerente !== "Todos") push("Gerente", vals.gerente, () => $("#f-gerente").selectedIndex = 0);
+  if (vals.gerente && vals.gerente !== "Todos") {
+    const label = $("#f-gerente")?.selectedOptions?.[0]?.text || vals.gerente;
+    push("Gerente", label, () => $("#f-gerente").selectedIndex = 0);
+  }
   if (vals.produtoId && vals.produtoId !== "Todas") {
     const label = $("#f-familia")?.selectedOptions?.[0]?.text || vals.produtoId;
     push("Produto", label, () => $("#f-familia").selectedIndex = 0);
@@ -734,6 +1386,7 @@ function filterRowsExcept(rows, except = {}, opts = {}) {
 function filterRows(rows) { return filterRowsExcept(rows, {}, { searchTerm: state.tableSearchTerm }); }
 
 function autoSnapViewToFilters() {
+  if (state.tableSearchTerm) return;
   const f = getFilterValues();
   let snap = null;
   if (f.produtoId && f.produtoId !== "Todas") snap = "prodsub";
@@ -747,18 +1400,70 @@ function autoSnapViewToFilters() {
 function ensureContracts(r) {
   if (r._contracts) return r._contracts;
   const n = 2 + Math.floor(Math.random() * 3), arr = [];
+  const periodYear = Number((state.period?.start || todayISO()).slice(0,4)) || new Date().getFullYear();
   for (let i = 0; i < n; i++) {
-    const id = `CT-${new Date().getFullYear()}-${String(Math.floor(1e6 + Math.random() * 9e6)).padStart(7, "0")}`;
+    const id = `CT-${periodYear}-${String(Math.floor(1e6 + Math.random() * 9e6)).padStart(7, "0")}`;
     const valor = Math.round((r.realizado / n) * (0.6 + Math.random() * 0.9)),
           meta  = Math.round((r.meta       / n) * (0.6 + Math.random() * 0.9));
     const sp = r.subproduto || r.produto;
-    arr.push({ id, produto: r.produto, subproduto: r.subproduto || "", prodOrSub: sp, qtd: 1, realizado: valor, meta, ating: meta ? (valor / meta) : 0, data: r.data, tipo: Math.random() > .5 ? "Venda direta" : "Digital" });
+    const canalVenda = r.canalVenda || (Math.random() > .5 ? "Agência física" : "Digital");
+    const tipoVenda = r.tipoVenda || (Math.random() > .5 ? "Venda consultiva" : "Venda direta");
+    const modalidadePagamento = r.modalidadePagamento || (Math.random() > .5 ? "À vista" : "Parcelado");
+    const baseISO = r.data || todayISO();
+    const baseDateUTC = dateUTCFromISO(baseISO);
+    const dueDateUTC = new Date(baseDateUTC);
+    dueDateUTC.setUTCDate(dueDateUTC.getUTCDate() + 10 + Math.floor(Math.random() * 25));
+    const dataVencimento = isoFromUTCDate(dueDateUTC);
+    let dataCancelamento = "";
+    let motivoCancelamento = "";
+    if (Math.random() < 0.25) {
+      const cancelDateUTC = new Date(dueDateUTC);
+      cancelDateUTC.setUTCDate(cancelDateUTC.getUTCDate() - Math.floor(Math.random() * 6));
+      dataCancelamento = isoFromUTCDate(cancelDateUTC);
+      motivoCancelamento = MOTIVOS_CANCELAMENTO[Math.floor(Math.random() * MOTIVOS_CANCELAMENTO.length)];
+    }
+    arr.push({
+      id,
+      produto: r.produto,
+      subproduto: r.subproduto || "",
+      prodOrSub: sp,
+      qtd: 1,
+      realizado: valor,
+      meta,
+      ating: meta ? (valor / meta) : 0,
+      data: r.data,
+      canalVenda,
+      tipoVenda,
+      modalidadePagamento,
+      gerente: r.gerenteNome || r.gerente,
+      dataVencimento,
+      dataCancelamento,
+      motivoCancelamento
+    });
   }
   r._contracts = arr; return arr;
 }
+
+const TREE_LEVEL_LABEL_RESOLVERS = {
+  diretoria: (row) => row.diretoriaNome || row.diretoria || "—",
+  gerencia:  (row) => row.regional || row.gerenciaNome || row.gerenciaRegional || "—",
+  agencia:   (row) => row.agenciaNome || row.agencia || "—",
+  gGestao:   (row) => row.gerenteGestaoNome || row.gerenteGestao || "—",
+  gerente:   (row) => row.gerenteNome || row.gerente || "—",
+  familia:   (row) => row.familia || "—",
+  prodsub:   (row) => row.prodOrSub || row.produto || row.subproduto || "—"
+};
+
+function resolveTreeLabel(levelKey, subset, fallback) {
+  if (!Array.isArray(subset) || !subset.length) return fallback;
+  const resolver = TREE_LEVEL_LABEL_RESOLVERS[levelKey];
+  if (!resolver) return fallback;
+  const label = resolver(subset[0]);
+  return label != null && label !== "" ? label : fallback;
+}
 function buildTree(list, startKey) {
-  const keyMap = { diretoria:"diretoria", gerencia:"gerenciaRegional", agencia:"agencia", gGestao:"gerenteGestao", gerente:"gerente", familia:"familia", prodsub:"prodOrSub", produto:"prodOrSub" };
-  const NEXT   = { diretoria:"gerencia",  gerencia:"agencia",         agencia:"gGestao", gGestao:"gerente",       gerente:"prodsub", familia:"contrato",   prodsub:"contrato" };
+  const keyMap = { diretoria:"diretoria", gerencia:"gerenciaRegional", agencia:"agencia", gGestao:"gerenteGestao", gerente:"gerente", familia:"familia", prodsub:"prodOrSub", produto:"prodOrSub", contrato:"contrato" };
+  const NEXT   = { diretoria:"gerencia",  gerencia:"agencia",         agencia:"gGestao", gGestao:"gerente",       gerente:"prodsub", familia:"contrato",   prodsub:"contrato", contrato:null };
 
   function group(arr, key){
     const m = new Map();
@@ -773,24 +1478,334 @@ function buildTree(list, startKey) {
     return { realizado, meta, qtd, ating: meta? realizado/meta : 0, data };
   }
 
+  function buildDetailGroups(arr){
+    const map = new Map();
+    arr.forEach(r => {
+      const canal = r.canalVenda || "Canal não informado";
+      const tipo = r.tipoVenda || "Tipo não informado";
+      const gerente = r.gerente || "—";
+      const modalidade = r.modalidadePagamento || (r.subproduto || "Modalidade não informada");
+      const key = `${canal}|${tipo}|${gerente}|${modalidade}`;
+      const bucket = map.get(key) || [];
+      bucket.push(r);
+      map.set(key, bucket);
+    });
+    return [...map.entries()].map(([comboKey, subset]) => {
+      const [canal, tipo, gerente, modalidade] = comboKey.split("|");
+      const a = agg(subset);
+      const dataVencimento = subset.reduce((curr, item) => {
+        if (!item.dataVencimento) return curr;
+        return !curr || item.dataVencimento > curr ? item.dataVencimento : curr;
+      }, "");
+      const dataCancelamento = subset.reduce((curr, item) => {
+        if (!item.dataCancelamento) return curr;
+        return !curr || item.dataCancelamento > curr ? item.dataCancelamento : curr;
+      }, "");
+      const motivoCancelamento = subset.reduce((curr, item) => curr || item.motivoCancelamento || "", "");
+      return {
+        canal,
+        tipo,
+        gerente,
+        modalidade,
+        realizado: a.realizado,
+        meta: a.meta,
+        qtd: a.qtd,
+        ating: a.ating,
+        data: a.data,
+        dataVencimento,
+        dataCancelamento,
+        motivoCancelamento
+      };
+    }).sort((a,b)=> (b.realizado||0) - (a.realizado||0));
+  }
+
   function buildLevel(arr, levelKey, level){
     if (levelKey === "contrato") {
-      return arr.flatMap(r => ensureContracts(r).map(c => ({
-        type:"contrato", level, label:c.id, realizado:c.realizado, meta:c.meta, qtd:c.qtd, ating:c.ating, data:c.data,
-        breadcrumb:[c.prodOrSub, r.gerente, r.gerenteGestao, r.agencia, r.gerenciaRegional, r.diretoria].filter(Boolean),
-        children:[]
-      })));
+      return arr.flatMap(r => ensureContracts(r).map(c => {
+        const detailGroups = buildDetailGroups([c]);
+        const detailBase = detailGroups[0] || null;
+        const detail = detailBase ? {
+          canal: detailBase.canal,
+          tipo: detailBase.tipo,
+          gerente: detailBase.gerente,
+          modalidade: detailBase.modalidade
+        } : null;
+        return {
+          type:"contrato",
+          level,
+          label:c.id,
+          realizado:c.realizado,
+          meta:c.meta,
+          qtd:c.qtd,
+          ating:c.ating,
+          data:c.data,
+          detail,
+          detailGroups,
+          breadcrumb:[
+            c.prodOrSub,
+            r.gerenteNome || r.gerente,
+            r.gerenteGestaoNome || r.gerenteGestao,
+            r.agenciaNome || r.agencia,
+            r.regional || r.gerenciaNome || r.gerenciaRegional,
+            r.diretoriaNome || r.diretoria
+          ].filter(Boolean),
+          children:[]
+        };
+      }));
     }
     const mapKey = keyMap[levelKey] || levelKey;
     return group(arr, mapKey).map(([k, subset]) => {
       const a = agg(subset), next = NEXT[levelKey];
+      const labelText = resolveTreeLabel(levelKey, subset, k);
       return {
-        type:"grupo", level, label:k, realizado:a.realizado, meta:a.meta, qtd:a.qtd, ating:a.ating, data:a.data,
-        breadcrumb:[k], children: next ? buildLevel(subset, next, level+1) : []
+        type:"grupo", level, label:labelText, realizado:a.realizado, meta:a.meta, qtd:a.qtd, ating:a.ating, data:a.data,
+        breadcrumb:[labelText], detailGroups: [],
+        children: next ? buildLevel(subset, next, level+1) : []
       };
     });
   }
   return buildLevel(list, startKey, 0);
+}
+
+function getContractSearchInput(){
+  return document.getElementById("busca");
+}
+
+function getContractSuggestPanel(){
+  return document.getElementById("contract-suggest");
+}
+
+function bindContractSuggestOutsideClick(){
+  if (contractSuggestDocBound) return;
+  const closeIfOutside = (event) => {
+    const wrap = document.querySelector(".card__search-autocomplete");
+    if (!wrap) return;
+    if (!wrap.contains(event.target)) closeContractSuggestions();
+  };
+  document.addEventListener("click", closeIfOutside);
+  window.addEventListener("resize", closeContractSuggestions);
+  document.addEventListener("scroll", closeContractSuggestions, true);
+  contractSuggestDocBound = true;
+}
+
+function wireContractSuggestionPanel(){
+  if (contractSuggestPanelBound) return;
+  const panel = getContractSuggestPanel();
+  if (!panel) return;
+  panel.addEventListener("pointerdown", (event) => {
+    const item = event.target.closest?.(".contract-suggest__item");
+    if (!item) return;
+    event.preventDefault();
+    const value = item.dataset.value || item.getAttribute("data-value") || item.textContent || "";
+    chooseContractSuggestion(value);
+  });
+  contractSuggestPanelBound = true;
+}
+
+function highlightContractTerm(text, term){
+  const value = String(text || "");
+  const lower = value.toLowerCase();
+  const needle = term.toLowerCase();
+  const idx = lower.indexOf(needle);
+  if (idx < 0) return escapeHTML(value);
+  const before = escapeHTML(value.slice(0, idx));
+  const match = escapeHTML(value.slice(idx, idx + term.length));
+  const after = escapeHTML(value.slice(idx + term.length));
+  return `${before}<mark>${match}</mark>${after}`;
+}
+
+function closeContractSuggestions(){
+  const panel = getContractSuggestPanel();
+  const input = getContractSearchInput();
+  if (panel) {
+    panel.hidden = true;
+    panel.innerHTML = "";
+  }
+  if (input) {
+    input.setAttribute("aria-expanded", "false");
+    input.removeAttribute("aria-activedescendant");
+  }
+  contractSuggestState.open = false;
+  contractSuggestState.items = [];
+  contractSuggestState.highlight = -1;
+}
+
+function setContractSuggestionHighlight(index){
+  const panel = getContractSuggestPanel();
+  const input = getContractSearchInput();
+  if (!panel || !contractSuggestState.open) return;
+  const items = panel.querySelectorAll(".contract-suggest__item");
+  if (!items.length) {
+    contractSuggestState.highlight = -1;
+    input?.removeAttribute("aria-activedescendant");
+    return;
+  }
+  let next = index;
+  if (next < 0) next = items.length - 1;
+  if (next >= items.length) next = 0;
+  contractSuggestState.highlight = next;
+  items.forEach((btn, i) => {
+    const highlighted = i === next;
+    btn.classList.toggle("is-highlight", highlighted);
+    btn.setAttribute("aria-selected", highlighted ? "true" : "false");
+    const id = `contract-opt-${i}`;
+    btn.id = id;
+    if (highlighted && input) {
+      input.setAttribute("aria-activedescendant", id);
+      const top = btn.offsetTop;
+      const bottom = top + btn.offsetHeight;
+      if (top < panel.scrollTop) panel.scrollTop = top;
+      else if (bottom > panel.scrollTop + panel.clientHeight) panel.scrollTop = bottom - panel.clientHeight;
+    }
+  });
+}
+
+function moveContractSuggestionHighlight(delta){
+  if (!contractSuggestState.open) return;
+  const panel = getContractSuggestPanel();
+  if (!panel || panel.hidden) return;
+  const items = panel.querySelectorAll(".contract-suggest__item");
+  if (!items.length) return;
+  const next = contractSuggestState.highlight + delta;
+  setContractSuggestionHighlight(next);
+}
+
+function getHighlightedContractSuggestion(){
+  if (!contractSuggestState.open) return null;
+  const idx = contractSuggestState.highlight;
+  if (idx < 0) return null;
+  return contractSuggestState.items[idx] || null;
+}
+
+function chooseContractSuggestion(value){
+  const input = getContractSearchInput();
+  const term = (value || "").trim();
+  if (input) {
+    input.value = term;
+    input.focus();
+  }
+  closeContractSuggestions();
+  requestAnimationFrame(() => {
+    if (term) commitContractSearch(term);
+    else commitContractSearch("", { showSpinner: true });
+  });
+}
+
+function refreshContractSuggestions(query = ""){
+  const input = getContractSearchInput();
+  const panel = getContractSuggestPanel();
+  if (!input || !panel) return;
+  bindContractSuggestOutsideClick();
+  wireContractSuggestionPanel();
+
+  const term = (query || "").trim();
+  contractSuggestState.term = term;
+  if (!term){
+    closeContractSuggestions();
+    return;
+  }
+
+  const list = Array.isArray(state.contractIndex) ? state.contractIndex : [];
+  const lowered = term.toLowerCase();
+  const matches = list.filter(id => id.toLowerCase().includes(lowered)).slice(0, 12);
+
+  if (!matches.length){
+    contractSuggestState.items = [];
+    contractSuggestState.highlight = -1;
+    contractSuggestState.open = true;
+    panel.innerHTML = `<div class="contract-suggest__empty">Nenhum contrato encontrado</div>`;
+    panel.hidden = false;
+    input.setAttribute("aria-expanded", "true");
+    input.removeAttribute("aria-activedescendant");
+    return;
+  }
+
+  contractSuggestState.items = matches;
+  contractSuggestState.highlight = -1;
+  contractSuggestState.open = true;
+  panel.innerHTML = matches.map((id, index) => `
+    <button type="button" class="contract-suggest__item" role="option" aria-selected="false" data-index="${index}" data-value="${escapeHTML(id)}">
+      <span>${highlightContractTerm(id, term)}</span>
+      <span class="contract-suggest__meta">Filtrar</span>
+    </button>
+  `).join("");
+  panel.hidden = false;
+  panel.scrollTop = 0;
+  input.setAttribute("aria-expanded", "true");
+  input.removeAttribute("aria-activedescendant");
+}
+
+function updateContractAutocomplete(){
+  const input = getContractSearchInput();
+  if (!input) return;
+  bindContractSuggestOutsideClick();
+  wireContractSuggestionPanel();
+
+  const ids = new Set();
+  (state._rankingRaw || []).forEach(row => {
+    ensureContracts(row).forEach(contract => {
+      if (contract?.id) ids.add(contract.id);
+    });
+  });
+
+  state.contractIndex = [...ids].sort();
+  if (input.value) refreshContractSuggestions(input.value);
+  else closeContractSuggestions();
+}
+
+function setContractSearchLoading(isLoading){
+  const wrap = document.querySelector(".card__search-autocomplete");
+  if (!wrap) return;
+  wrap.classList.toggle("is-loading", Boolean(isLoading));
+}
+
+async function commitContractSearch(rawTerm, opts = {}) {
+  const { showSpinner = true } = opts || {};
+  const term = (rawTerm || "").trim();
+
+  contractSuggestState.pending = term;
+  const run = async () => {
+    if (term) {
+      if (state.tableView !== "contrato") {
+        state.lastNonContractView = state.tableView;
+      }
+      state.tableView = "contrato";
+      setActiveChip("contrato");
+    } else if (state.tableView === "contrato") {
+      const fallback = state.lastNonContractView && state.lastNonContractView !== "contrato"
+        ? state.lastNonContractView
+        : "diretoria";
+      state.tableView = fallback;
+      setActiveChip(state.tableView);
+    }
+
+    state.tableSearchTerm = term;
+    closeContractSuggestions();
+    await Promise.resolve(applyFiltersAndRender());
+    if (!term) refreshContractSuggestions("");
+  };
+
+  const label = term ? "Filtrando contratos…" : "Atualizando tabela…";
+
+  if (showSpinner) {
+    await withSpinner(async () => {
+      setContractSearchLoading(true);
+      try {
+        await run();
+      } finally {
+        setContractSearchLoading(false);
+        contractSuggestState.pending = null;
+      }
+    }, label);
+  } else {
+    setContractSearchLoading(true);
+    try {
+      await run();
+    } finally {
+      setContractSearchLoading(false);
+      contractSuggestState.pending = null;
+    }
+  }
 }
 
 /* ===== UI ===== */
@@ -808,13 +1823,25 @@ function initCombos() {
 
   // visíveis
   fill("#f-segmento", [{value:"Todos",label:"Todos"},{value:"Empresas",label:"Empresas"},{value:"Negócios",label:"Negócios"},{value:"MEI",label:"MEI"}]);
-  fill("#f-diretoria", [{value:"Todas",label:"Todas"},{value:"DR 01",label:"DR 01"},{value:"DR 02",label:"DR 02"},{value:"DR 03",label:"DR 03"}]);
-  fill("#f-gerencia",  [{value:"Todas",label:"Todas"},{value:"GR 01",label:"GR 01"},{value:"GR 02",label:"GR 02"},{value:"GR 03",label:"GR 03"},{value:"GR 04",label:"GR 04"}]);
+  const dirOptions = [{ value: "Todas", label: "Todas" }].concat(
+    RANKING_DIRECTORIAS.map(dir => ({ value: dir.id, label: `${dir.id} • ${dir.nome}` }))
+  );
+  const gerOptions = [{ value: "Todas", label: "Todas" }].concat(
+    RANKING_GERENCIAS.map(gr => ({ value: gr.id, label: `${gr.id} • ${gr.nome}` }))
+  );
+  fill("#f-diretoria", dirOptions);
+  fill("#f-gerencia", gerOptions);
 
   // avançado
-  fill("#f-agencia",   [{value:"Todas",label:"Todas"},{value:"Ag 1001",label:"Ag 1001"},{value:"Ag 1002",label:"Ag 1002"},{value:"Ag 1003",label:"Ag 1003"},{value:"Ag 1004",label:"Ag 1004"}]);
+  const agOptions = [{ value: "Todas", label: "Todas" }].concat(
+    RANKING_AGENCIAS.map(ag => ({ value: ag.id, label: ag.nome }))
+  );
+  fill("#f-agencia", agOptions);
   fill("#f-ggestao",   [{value:"Todos",label:"Todos"},{value:"GG 01",label:"GG 01"},{value:"GG 02",label:"GG 02"},{value:"GG 03",label:"GG 03"}]);
-  fill("#f-gerente",   [{value:"Todos",label:"Todos"},{value:"Gerente 1",label:"Gerente 1"},{value:"Gerente 2",label:"Gerente 2"},{value:"Gerente 3",label:"Gerente 3"},{value:"Gerente 4",label:"Gerente 4"},{value:"Gerente 5",label:"Gerente 5"}]);
+  const gerenteOptions = [{ value: "Todos", label: "Todos" }].concat(
+    RANKING_GERENTES.map(ger => ({ value: ger.id, label: `${ger.id} • ${ger.nome}` }))
+  );
+  fill("#f-gerente", gerenteOptions);
 
   // #f-familia = todos os cards
   const products = [{value:"Todas",label:"Todas"}].concat(
@@ -826,11 +1853,16 @@ function initCombos() {
   fill("#f-produto", produtosExemplo);
 }
 function bindEvents() {
-  $("#btn-consultar")?.addEventListener("click", () => {
-    autoSnapViewToFilters();
-    applyFiltersAndRender();
-    if (state._dataset) renderFamilias(state._dataset.sections, state._dataset.summary);
-    renderAppliedFilters();
+  $("#btn-consultar")?.addEventListener("click", async () => {
+    await withSpinner(async () => {
+      autoSnapViewToFilters();
+      applyFiltersAndRender();
+      if (state._dataset) renderFamilias(state._dataset.sections, state._dataset.summary);
+      renderAppliedFilters();
+      renderCampanhasView();
+      if (state.activeView === "ranking") renderRanking();
+    }, "Aplicando filtros…");
+    closeMobileFilters();
   });
 
   $("#btn-abrir-filtros")?.addEventListener("click", () => {
@@ -849,32 +1881,88 @@ function bindEvents() {
   $$(".tab").forEach(t => {
     t.addEventListener("click", () => {
       if (t.classList.contains("is-active")) return;
-      $$(".tab").forEach(x => x.classList.remove("is-active"));
-      t.classList.add("is-active");
       const view = t.dataset.view;
+      setActiveTab(view);
       if (view === "table") switchView("table");
       else if (view === "ranking") switchView("ranking");
       else if (view === "exec") switchView("exec");
+      else if (view === "campanhas") switchView("campanhas");
       else switchView("cards");
     });
   });
 
   ["#f-segmento","#f-diretoria","#f-gerencia","#f-agencia","#f-ggestao","#f-gerente","#f-familia","#f-subproduto","#f-status-kpi"].forEach(sel => {
-    $(sel)?.addEventListener("change", () => {
-      autoSnapViewToFilters();
-      applyFiltersAndRender();
-      if (state._dataset) renderFamilias(state._dataset.sections, state._dataset.summary);
-      renderAppliedFilters();
-      if (state.activeView === "ranking") renderRanking();
+    $(sel)?.addEventListener("change", async () => {
+      await withSpinner(async () => {
+        autoSnapViewToFilters();
+        applyFiltersAndRender();
+        if (state._dataset) renderFamilias(state._dataset.sections, state._dataset.summary);
+        renderAppliedFilters();
+        renderCampanhasView();
+        if (state.activeView === "ranking") renderRanking();
+      }, "Atualizando filtros…");
     });
   });
 
-  $("#busca")?.addEventListener("input", (e) => {
-    state.tableSearchTerm = (e.target.value || "").trim();
-    applyFiltersAndRender();
-  });
+  const searchInput = $("#busca");
+  if (searchInput) {
+    searchInput.addEventListener("input", async (e) => {
+      const value = e.target.value || "";
+      refreshContractSuggestions(value);
+      if (!value.trim() && state.tableSearchTerm) {
+        await commitContractSearch("", { showSpinner: true });
+      }
+    });
+    searchInput.addEventListener("keydown", async (e) => {
+      if (e.key === "ArrowDown") {
+        const value = e.currentTarget.value || "";
+        if (!contractSuggestState.open) refreshContractSuggestions(value);
+        if (contractSuggestState.open) moveContractSuggestionHighlight(1);
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        const value = e.currentTarget.value || "";
+        if (!contractSuggestState.open) refreshContractSuggestions(value);
+        if (contractSuggestState.open) moveContractSuggestionHighlight(-1);
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        const highlighted = getHighlightedContractSuggestion();
+        const value = highlighted ?? e.currentTarget.value;
+        await commitContractSearch(value);
+        return;
+      }
+      if (e.key === "Escape") {
+        closeContractSuggestions();
+      }
+    });
+    searchInput.addEventListener("change", async (e) => {
+      const value = e.target.value || "";
+      const term = (value || "").trim();
+      if (term === state.tableSearchTerm || term === contractSuggestState.pending) {
+        closeContractSuggestions();
+        return;
+      }
+      if (!term) {
+        await commitContractSearch("", { showSpinner: true });
+      } else {
+        await commitContractSearch(term);
+      }
+    });
+    searchInput.addEventListener("focus", (e) => {
+      const value = e.target.value || "";
+      if (value.trim()) refreshContractSuggestions(value);
+    });
+    searchInput.addEventListener("blur", () => {
+      setTimeout(() => closeContractSuggestions(), 120);
+    });
+  }
 
   $("#btn-export")?.remove();
+  setupMobileFilters();
 }
 
 /* Reordenar filtros */
@@ -946,11 +2034,13 @@ function ensureChatWidget(){
     <button id="chat-launcher" class="chatw__btn" aria-label="Abrir chat de dúvidas">
       <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M4 4h16a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H8.4l-3.6 3a1 1 0 0 1-1.6-.8V6a2 2 0 0 1 2-2zm2 4v2h12V8H6zm0 4v2h9v-2H6z"/></svg>
     </button>
-    <section id="chat-panel" class="chatw__panel" aria-hidden="true" role="dialog" aria-label="Chat POBJ">
+    <section id="chat-panel" class="chatw__panel" aria-hidden="true" role="dialog" aria-label="Chat POBJ e campanhas">
       <header class="chatw__header">
-        <div class="chatw__title">Assistente POBJ</div>
+        <div class="chatw__title">Assistente POBJ &amp; Campanhas</div>
         <button id="chat-close" class="chatw__close" aria-label="Fechar chat"><i class="ti ti-x"></i></button>
       </header>
+
+      <p class="chatw__disclaimer">Assistente virtual com IA — respostas podem conter erros.</p>
 
       <div id="chat-body">
         <!-- Se modo iframe, eu coloco aqui; senão, uso a UI nativa abaixo -->
@@ -959,7 +2049,7 @@ function ensureChatWidget(){
       <div id="chat-ui-native" style="display:none;">
         <div id="chat-messages" class="chatw__msgs" aria-live="polite"></div>
         <form id="chat-form" class="chatw__form" autocomplete="off">
-          <input id="chat-input" type="text" placeholder="Pergunte sobre o POBJ…" required />
+          <input id="chat-input" type="text" placeholder="Pergunte sobre o POBJ ou campanhas…" required />
           <button id="chat-send" type="submit">Enviar</button>
         </form>
       </div>
@@ -1033,7 +2123,7 @@ function ensureChatWidget(){
     };
 
     // Mensagem de boas-vindas
-    addMsg("bot","Olá! Posso ajudar com dúvidas sobre o POBJ. O que você quer saber?");
+    addMsg("bot","Olá! Posso ajudar com dúvidas sobre o POBJ e campanhas. O que você quer saber?");
 
     form.addEventListener("submit", async (e)=>{
       e.preventDefault();
@@ -1083,16 +2173,20 @@ function ensureChatWidget(){
 /* ===== Troca de view (com spinner) ===== */
 async function switchView(next) {
   const label =
-    next === "table"   ? "Montando detalhamento…" :
-    next === "ranking" ? "Calculando ranking…"    :
-    next === "exec"    ? "Abrindo visão executiva…" :
-                         "Carregando…";
+    next === "table"     ? "Montando detalhamento…" :
+    next === "ranking"   ? "Calculando ranking…"    :
+    next === "exec"      ? "Abrindo visão executiva…" :
+    next === "campanhas" ? "Abrindo campanhas…" :
+                           "Carregando…";
+
+  setActiveTab(next);
 
   await withSpinner(async () => {
-    const views = { cards:"#view-cards", table:"#view-table", ranking:"#view-ranking", exec:"#view-exec" };
+    const views = { cards:"#view-cards", table:"#view-table", ranking:"#view-ranking", exec:"#view-exec", campanhas:"#view-campanhas" };
 
     if (next === "ranking" && !$("#view-ranking")) createRankingView();
     if (next === "exec") createExecutiveView();
+    if (next === "campanhas") ensureCampanhasView();
 
 
     Object.values(views).forEach(sel => $(sel)?.classList.add("hidden"));
@@ -1108,6 +2202,7 @@ async function switchView(next) {
 
     if (next === "ranking") renderRanking();
     if (next === "exec")    renderExecutiveView();   // <- ADICIONE ESTA LINHA
+    if (next === "campanhas") renderCampanhasView();
 
     const el = $(views[next]) || $("#view-cards");
     el.classList.remove("hidden");
@@ -1119,7 +2214,14 @@ async function switchView(next) {
 
 /* ===== Resumo (Indicadores / Pontos) ===== */
 function hitbarClass(p){ return p<50 ? "hitbar--low" : (p<100 ? "hitbar--warn" : "hitbar--ok"); }
-function renderResumoKPI(summary, visibleItemsHitCount, visiblePointsHit) {
+function renderResumoKPI(summary, context = {}) {
+  const {
+    visibleItemsHitCount = null,
+    visiblePointsHit = null,
+    visibleVarAtingido = null,
+    visibleVarMeta = null
+  } = context || {};
+
   let kpi = $("#kpi-summary");
   if (!kpi) {
     kpi = document.createElement("div");
@@ -1128,46 +2230,62 @@ function renderResumoKPI(summary, visibleItemsHitCount, visiblePointsHit) {
     $("#grid-familias").prepend(kpi);
   }
 
-  const pctInd = summary.indicadoresTotal
-    ? (visibleItemsHitCount / summary.indicadoresTotal)
-    : (summary.indicadoresPct || 0);
+  const indicadoresAtingidos = toNumber(summary.indicadoresAtingidos ?? visibleItemsHitCount ?? 0);
+  const indicadoresTotal = toNumber(summary.indicadoresTotal ?? 0);
+  const pontosAtingidos = toNumber(summary.pontosAtingidos ?? visiblePointsHit ?? 0);
+  const pontosTotal = toNumber(summary.pontosPossiveis ?? 0);
 
-  const pctPts = summary.pontosPossiveis
-    ? (visiblePointsHit / summary.pontosPossiveis)
-    : (summary.pontosPct || 0);
+  const varTotalBase = summary.varPossivel != null
+    ? toNumber(summary.varPossivel)
+    : (visibleVarMeta != null ? toNumber(visibleVarMeta) : Math.round((summary.pontosPossiveis || 0) * 1000));
+  const varAtingidoBase = summary.varAtingido != null
+    ? toNumber(summary.varAtingido)
+    : (visibleVarAtingido != null ? toNumber(visibleVarAtingido) : Math.round(varTotalBase * (summary.varPct || 0)));
 
-  const varPossivel = (summary.varPossivel != null)
-    ? summary.varPossivel
-    : Math.round((summary.pontosPossiveis || 0) * 1000);
+  const formatDisplay = (type, value) => type === "brl" ? formatBRLReadable(value) : formatIntReadable(value);
+  const formatFull = (type, value) => {
+    const n = Math.round(toNumber(value));
+    return type === "brl" ? fmtBRL.format(n) : fmtINT.format(n);
+  };
+  const buildTitle = (label, type, globalValue, visibleValue) => {
+    let title = `${label}: ${formatFull(type, globalValue)}`;
+    if (visibleValue != null && Math.round(toNumber(visibleValue)) !== Math.round(toNumber(globalValue))) {
+      title += ` · Filtro atual: ${formatFull(type, visibleValue)}`;
+    }
+    return title;
+  };
 
-  const varAtingido = (summary.varAtingido != null)
-    ? summary.varAtingido
-    : Math.round(varPossivel * pctPts);
-
-  const pctVar = varPossivel ? (varAtingido / varPossivel) : 0;
-
-  const f = { int:v=>fmtINT.format(v), brl:v=>fmtBRL.format(Math.round(v||0)) };
-
-  const strip = (titulo, iconClass, atingidos, possiveis, pct, fmtType="int") => {
-    const pct100 = Math.min(100, Math.max(0, pct * 100));
-    const hbClass = pct100 < 50 ? "hitbar--low" : (pct100 < 100 ? "hitbar--warn" : "hitbar--ok");
+  const buildCard = (titulo, iconClass, atingidos, total, fmtType, visibleAting = null, visibleTotal = null) => {
+    const pctRaw = total ? (atingidos / total) * 100 : 0;
+    const pct100 = Math.max(0, Math.min(100, pctRaw));
+    const hbClass = hitbarClass(pctRaw);
+    const pctLabel = `${pctRaw.toFixed(1)}%`;
+    const atgTitle = buildTitle("Atingidos", fmtType, atingidos, visibleAting);
+    const totTitle = buildTitle("Total", fmtType, total, visibleTotal);
     return `
-      <div class="kpi-pill kpi-strip">
-        <span class="kpi-icon"><i class="${iconClass}"></i></span>
-        <span class="kpi-strip__label has-ellipsis" title="${titulo}">${titulo}</span>
-        <span class="kpi-stat has-ellipsis" title="Atingidos: ${f[fmtType](atingidos)}">Atg: <strong title="${f[fmtType](atingidos)}">${f[fmtType](atingidos)}</strong></span>
-        <span class="kpi-stat has-ellipsis" title="Total: ${f[fmtType](possiveis)}">Total: <strong title="${f[fmtType](possiveis)}">${f[fmtType](possiveis)}</strong></span>
-        <span class="hitbar ${hbClass}">
+      <div class="kpi-pill">
+        <div class="kpi-strip__main">
+          <span class="kpi-icon"><i class="${iconClass}"></i></span>
+          <div class="kpi-strip__text">
+            <span class="kpi-strip__label" title="${titulo}">${titulo}</span>
+            <div class="kpi-strip__stats">
+              <span class="kpi-stat" title="${atgTitle}">Atg: <strong>${formatDisplay(fmtType, atingidos)}</strong></span>
+              <span class="kpi-stat" title="${totTitle}">Total: <strong>${formatDisplay(fmtType, total)}</strong></span>
+            </div>
+          </div>
+        </div>
+        <div class="hitbar ${hbClass}" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${pct100.toFixed(1)}" aria-valuetext="${titulo}: ${pctLabel}">
           <span class="hitbar__track"><span class="hitbar__fill" style="width:${pct100}%"></span></span>
-          <strong title="${pct100.toFixed(1)}%">${pct100.toFixed(1)}%</strong>
-        </span>
+          <strong title="${pctLabel}">${pctLabel}</strong>
+        </div>
       </div>`;
   };
 
-  kpi.innerHTML =
-    strip("Indicadores", "ti ti-list-check", visibleItemsHitCount, summary.indicadoresTotal || 0, pctInd, "int") +
-    strip("Pontos",       "ti ti-medal",      visiblePointsHit,     summary.pontosPossiveis   || 0, pctPts, "int") +
-    strip("Variável",     "ti ti-cash",       varAtingido,          varPossivel,                  pctVar, "brl");
+  kpi.innerHTML = [
+    buildCard("Indicadores", "ti ti-list-check", indicadoresAtingidos, indicadoresTotal, "int", visibleItemsHitCount),
+    buildCard("Pontos", "ti ti-medal", pontosAtingidos, pontosTotal, "int", visiblePointsHit),
+    buildCard("Variável", "ti ti-cash", varAtingidoBase, varTotalBase, "brl", visibleVarAtingido, visibleVarMeta)
+  ].join("");
 }
 
 /* ===== Tooltip dos cards ===== */
@@ -1271,6 +2389,9 @@ function renderFamilias(sections, summary){
 
   let atingidosVisiveis = 0;
   let pontosAtingidosVisiveis = 0;
+  let varRealVisiveis = 0;
+  let varMetaVisiveis = 0;
+  let hasVisibleVar = false;
 
   const kpiHolder = document.createElement("div");
   kpiHolder.id = "kpi-summary";
@@ -1292,6 +2413,17 @@ function renderFamilias(sections, summary){
 
     const sectionTotalPoints = sec.items.reduce((acc,i)=> acc + (i.peso||0), 0);
     const sectionPointsHit   = sec.items.filter(i=> i.atingido).reduce((acc,i)=> acc + (i.peso||0), 0);
+    const sectionVarMeta     = sec.items.reduce((acc,i)=> acc + (i.variavelMeta || 0), 0);
+    const sectionVarReal     = sec.items.reduce((acc,i)=> acc + (i.variavelReal || 0), 0);
+
+    const sectionPointsHitDisp = formatIntReadable(sectionPointsHit);
+    const sectionPointsTotalDisp = formatIntReadable(sectionTotalPoints);
+    const sectionPointsHitFull = fmtINT.format(Math.round(sectionPointsHit));
+    const sectionPointsTotalFull = fmtINT.format(Math.round(sectionTotalPoints));
+    const sectionVarRealDisp = formatBRLReadable(sectionVarReal);
+    const sectionVarMetaDisp = formatBRLReadable(sectionVarMeta);
+    const sectionVarRealFull = fmtBRL.format(Math.round(sectionVarReal));
+    const sectionVarMetaFull = fmtBRL.format(Math.round(sectionVarMeta));
 
     const sectionEl = document.createElement("section");
     sectionEl.className = "fam-section";
@@ -1300,7 +2432,10 @@ function renderFamilias(sections, summary){
       <header class="fam-section__header">
         <div class="fam-section__title">
           <span>${sec.label}</span>
-          <small class="fam-section__meta">pontos: ${fmtINT.format(sectionPointsHit)}/${fmtINT.format(sectionTotalPoints)}</small>
+          <small class="fam-section__meta">
+            <span class="fam-section__meta-item" title="Pontos: ${sectionPointsHitFull} / ${sectionPointsTotalFull}">Pontos: ${sectionPointsHitDisp} / ${sectionPointsTotalDisp}</span>
+            <span class="fam-section__meta-item" title="Variável: ${sectionVarRealFull} / ${sectionVarMetaFull}">Variável: ${sectionVarRealDisp} / ${sectionVarMetaDisp}</span>
+          </small>
         </div>
       </header>
       <div class="fam-section__grid"></div>`;
@@ -1313,8 +2448,24 @@ function renderFamilias(sections, summary){
       const badgeTxt   = pct >= 100 ? `${Math.round(pct)}%` : `${pct.toFixed(1)}%`;
       const narrowStyle= badgeTxt.length >= 5 ? 'style="font-size:11px"' : '';
 
+      const variavelMeta = f.variavelMeta || 0;
+      const variavelReal = f.variavelReal || 0;
+      hasVisibleVar = true;
+      varMetaVisiveis += variavelMeta;
+      varRealVisiveis += variavelReal;
+      const varRatio = variavelMeta ? (variavelReal / variavelMeta) : (f.atingVariavel ?? f.ating ?? 0);
+      const varPct = Math.max(0, varRatio * 100);
+      const varPctLabel = `${varPct.toFixed(1)}%`;
+      const varFillPct = Math.max(0, Math.min(100, varPct));
+      const varTrackClass = varPct < 50 ? "var--low" : (varPct < 100 ? "var--warn" : "var--ok");
+      const varRealCompact = formatCompactBRL(variavelReal);
+      const varMetaCompact = formatCompactBRL(variavelMeta);
+      const varAccessible = `${varPctLabel} (${fmtBRL.format(Math.round(variavelReal))} de ${fmtBRL.format(Math.round(variavelMeta))})`;
+
       const realizadoTxt = formatByMetric(f.metric, f.realizado);
       const metaTxt      = formatByMetric(f.metric, f.meta);
+      const realizadoFull = formatMetricFull(f.metric, f.realizado);
+      const metaFull      = formatMetricFull(f.metric, f.meta);
 
       grid.insertAdjacentHTML("beforeend", `
         <article class="prod-card" tabindex="0" data-prod-id="${f.id}">
@@ -1331,8 +2482,20 @@ function renderFamilias(sections, summary){
           </div>
 
           <div class="prod-card__kpis">
-            <div class="kv"><small>Realizado</small><strong class="has-ellipsis" title="${realizadoTxt}">${realizadoTxt}</strong></div>
-            <div class="kv"><small>Meta</small><strong class="has-ellipsis" title="${metaTxt}">${metaTxt}</strong></div>
+            <div class="kv"><small>Realizado</small><strong class="has-ellipsis" title="${realizadoFull}">${realizadoTxt}</strong></div>
+            <div class="kv"><small>Meta</small><strong class="has-ellipsis" title="${metaFull}">${metaTxt}</strong></div>
+          </div>
+
+          <div class="prod-card__var">
+            <div class="prod-card__var-head">
+              <small>Remuneração variável</small>
+              <strong title="${varPctLabel}">${varPctLabel}</strong>
+            </div>
+            <div class="prod-card__var-track ${varTrackClass}" role="progressbar" aria-valuemin="0" aria-valuemax="150" aria-valuenow="${Math.round(Math.min(varPct,150))}" aria-valuetext="${varAccessible}" aria-label="Atingimento da remuneração variável">
+              <span class="prod-card__var-fill" style="width:${varFillPct}%"></span>
+              <span class="prod-card__var-label prod-card__var-label--current" title="${fmtBRL.format(Math.round(variavelReal))}">${varRealCompact}</span>
+              <span class="prod-card__var-label prod-card__var-label--target" title="${fmtBRL.format(Math.round(variavelMeta))}">${varMetaCompact}</span>
+            </div>
           </div>
 
           <div class="prod-card__foot">Atualizado em ${f.ultimaAtualizacao}</div>
@@ -1344,7 +2507,12 @@ function renderFamilias(sections, summary){
     host.appendChild(sectionEl);
   });
 
-  renderResumoKPI(summary, atingidosVisiveis, pontosAtingidosVisiveis);
+  renderResumoKPI(summary, {
+    visibleItemsHitCount: atingidosVisiveis,
+    visiblePointsHit: pontosAtingidosVisiveis,
+    visibleVarAtingido: hasVisibleVar ? varRealVisiveis : null,
+    visibleVarMeta: hasVisibleVar ? varMetaVisiveis : null
+  });
 
   $$(".prod-card").forEach(card=>{
     const tip = card.querySelector(".kpi-tip");
@@ -1403,14 +2571,16 @@ function ensureExecStyles(){
     .exec-head{display:flex;align-items:flex-end;justify-content:space-between;gap:12px}
     .seg-mini.segmented{padding:2px;border-radius:8px}
     .seg-mini .seg-btn{padding:6px 8px;font-size:12px}
-    .exec-chart{background:#fff;border:1px solid var(--stroke);border-radius:14px;box-shadow:var(--shadow);padding:12px}
-    .chart{width:100%;overflow:hidden}
+    .exec-chart{background:#fff;border:1px solid var(--stroke);border-radius:14px;box-shadow:var(--shadow);padding:20px;margin-bottom:20px}
+    .chart{width:100%;overflow:hidden;padding:20px;border-radius:12px;background:#fff}
     .chart svg{display:block;width:100%;height:auto}
     .chart-legend{display:flex;gap:12px;flex-wrap:wrap;margin-top:8px}
     .legend-item{display:inline-flex;align-items:center;gap:6px;color:#475569;font-weight:700}
     .legend-swatch{width:14px;height:6px;border-radius:999px;background:#cbd5e1;border:1px solid #94a3b8}
     .legend-swatch--meta{background:#93c5fd;border-color:#60a5fa}
     .legend-swatch--real{background:#86efac;border-color:#4ade80}
+    .legend-swatch--monthly-meta{background:transparent;border:1.5px dashed #2563eb;height:8px}
+    .legend-swatch--monthly-real{background:#2563eb;border-color:#1d4ed8;height:8px}
     .legend-swatch--bars{background:#e5e7eb;border-color:#cbd5e1;height:10px}
     .exec-panel .exec-h{display:flex;align-items:center;justify-content:space-between;gap:10px}
   `;
@@ -1421,103 +2591,50 @@ function ensureExecStyles(){
 function createExecutiveView(){
   ensureExecStyles();
 
-  let host = document.getElementById("view-exec");
-  if(!host){
-    host = document.createElement("section");
-    host.id = "view-exec";
-    host.className = "hidden view-panel";
-    document.querySelector(".container")?.appendChild(host);
+  const host = document.getElementById("view-exec");
+  if (!host) return;
+
+  if (!state.exec) {
+    state.exec = { rankMode: "top", statusMode: "quase", chartMode: "diario" };
   }
+  state.exec.rankMode  = state.exec.rankMode  || "top";
+  state.exec.statusMode= state.exec.statusMode|| "quase";
+  state.exec.chartMode = state.exec.chartMode || "diario";
 
-  // se já montei, não refaço o DOM (só re-renderizo os dados)
-  if (host.querySelector("#exec-kpis")) return;
-
-  host.innerHTML = `
-    <section class="card card--exec">
-      <header class="card__header exec-head">
-        <div class="title-subtitle">
-          <!-- sem título -->
-          <div class="muted" id="exec-context"></div>
-        </div>
-      </header>
-
-      <!-- KPIs topo -->
-      <div id="exec-kpis" class="exec-kpis"></div>
-
-      <!-- Gráfico de evolução -->
-      <section class="exec-panel exec-span-2 exec-chart">
-        <div class="exec-h"><span id="exec-chart-title">Evolução do mês</span></div>
-        <div id="exec-chart" class="chart" role="img" aria-label="Evolução diária com linhas de meta e realizado"></div>
-        <div class="chart-legend">
-          <span class="legend-item"><span class="legend-swatch legend-swatch--bars"></span>Diário realizado (barras)</span>
-          <span class="legend-item"><span class="legend-swatch legend-swatch--real"></span>Realizado acumulado (linha)</span>
-          <span class="legend-item"><span class="legend-swatch legend-swatch--meta"></span>Meta acumulada (linha)</span>
-        </div>
-      </section>
-
-      <div class="exec-grid">
-        <!-- Painel de ranking com toggle Top/Bottom -->
-        <section class="exec-panel" id="exec-rank-panel">
-          <div class="exec-h">
-            <span id="exec-rank-title">Desempenho por unidade</span>
-            <div class="segmented seg-mini" role="tablist" aria-label="Ordenação">
-              <button type="button" class="seg-btn is-active" data-rk="top">Top 5</button>
-              <button type="button" class="seg-btn" data-rk="bottom">Bottom 5</button>
-            </div>
-          </div>
-          <div id="exec-rank" class="rank-mini"></div>
-        </section>
-
-        <!-- Painel de status com 3 visões -->
-        <section class="exec-panel" id="exec-status-panel">
-          <div class="exec-h">
-            <span id="exec-status-title">Status das unidades</span>
-            <div class="segmented seg-mini" role="tablist" aria-label="Status">
-              <button type="button" class="seg-btn" data-st="hit">Atingidas</button>
-              <button type="button" class="seg-btn is-active" data-st="quase">Quase lá</button>
-              <button type="button" class="seg-btn" data-st="longe">Longe</button>
-            </div>
-          </div>
-          <div id="exec-status-list" class="list-mini"></div>
-        </section>
-
-        <section class="exec-panel exec-span-2">
-          <h4 class="exec-h"><span id="exec-ritmo-title">Ritmo do mês</span></h4>
-          <div id="exec-ritmo" class="ritmo"></div>
-        </section>
-
-        <section class="exec-panel exec-span-2">
-          <h4 class="exec-h"><span id="exec-heatmap-title">Heatmap</span></h4>
-          <div id="exec-heatmap" class="hm"></div>
-        </section>
-      </div>
-    </section>`;
-
-  // estado local da executiva
-  if (!state.exec) state.exec = { rankMode: "top", statusMode: "quase" };
-
-  // listeners dos segmented da executiva
-  host.querySelectorAll('#exec-rank-panel .seg-btn').forEach(b=>{
-    b.addEventListener('click', ()=>{
-      host.querySelectorAll('#exec-rank-panel .seg-btn').forEach(x=>x.classList.remove('is-active'));
-      b.classList.add('is-active');
-      state.exec.rankMode = b.dataset.rk; // "top" | "bottom"
-      if (state.activeView==='exec') renderExecutiveView();
+  const syncSegmented = (containerSelector, dataAttr, stateKey, fallback) => {
+    const container = host.querySelector(containerSelector);
+    if (!container) return;
+    const buttons = container.querySelectorAll('.seg-btn');
+    if (!buttons.length) return;
+    const active = state.exec[stateKey] || fallback;
+    buttons.forEach(btn => {
+      const value = btn.dataset[dataAttr] || fallback;
+      btn.classList.toggle('is-active', value === active);
+      if (!btn.dataset.execBound) {
+        btn.dataset.execBound = 'true';
+        btn.addEventListener('click', () => {
+          state.exec[stateKey] = value;
+          buttons.forEach(b => b.classList.toggle('is-active', b === btn));
+          if (state.activeView === 'exec') renderExecutiveView();
+        });
+      }
     });
-  });
-  host.querySelectorAll('#exec-status-panel .seg-btn').forEach(b=>{
-    b.addEventListener('click', ()=>{
-      host.querySelectorAll('#exec-status-panel .seg-btn').forEach(x=>x.classList.remove('is-active'));
-      b.classList.add('is-active');
-      state.exec.statusMode = b.dataset.st; // "hit" | "quase" | "longe"
-      if (state.activeView==='exec') renderExecutiveView();
-    });
-  });
+  };
 
-  // filtros disparando re-render quando a aba executiva estiver aberta
-  const execSel = ["#f-segmento","#f-diretoria","#f-gerencia","#f-agencia","#f-ggestao","#f-gerente","#f-familia","#f-subproduto","#f-status-kpi"];
-  execSel.forEach(sel => $(sel)?.addEventListener("change", ()=>{ if (state.activeView==='exec') renderExecutiveView(); }));
-  $("#btn-consultar")?.addEventListener("click", ()=>{ if (state.activeView==='exec') renderExecutiveView(); });
+  syncSegmented('#exec-rank-panel', 'rk', 'rankMode', 'top');
+  syncSegmented('#exec-status-panel', 'st', 'statusMode', 'quase');
+  syncSegmented('#exec-chart-toggle', 'chart', 'chartMode', 'diario');
+
+  if (!host.dataset.execFiltersBound) {
+    const execSel = ["#f-segmento","#f-diretoria","#f-gerencia","#f-agencia","#f-ggestao","#f-gerente","#f-familia","#f-subproduto","#f-status-kpi"];
+    execSel.forEach(sel => $(sel)?.addEventListener("change", () => {
+      if (state.activeView === 'exec') renderExecutiveView();
+    }));
+    $("#btn-consultar")?.addEventListener("click", () => {
+      if (state.activeView === 'exec') renderExecutiveView();
+    });
+    host.dataset.execFiltersBound = "true";
+  }
 }
 
 /* Helpers de agregação para a Visão Executiva */
@@ -1599,12 +2716,20 @@ function makeDailySeries(totalMeta, totalReal, startISO, endISO){
   const labels = days.map(d=> String(d.getUTCDate()).padStart(2,"0"));
   return { labels, dailyReal, cumMeta, cumReal };
 }
+
+function chartDimensions(container, fallbackW=900, fallbackH=260){
+  if (!container) return { width: fallbackW, height: fallbackH };
+  const styles = window.getComputedStyle(container);
+  const padL = parseFloat(styles.paddingLeft) || 0;
+  const padR = parseFloat(styles.paddingRight) || 0;
+  const width = Math.max(320, (container.clientWidth || fallbackW) - padL - padR);
+  return { width, height: fallbackH };
+}
 function buildExecChart(container, series){
-  const W = container.clientWidth || 900;
-  const H = 260;
-  const m = { t:18, r:18, b:26, l:52 };
-  const iw = W - m.l - m.r;
-  const ih = H - m.t - m.b;
+  const { width: W, height: H } = chartDimensions(container);
+  const m = { t:20, r:20, b:40, l:64 };
+  const iw = Math.max(0, W - m.l - m.r);
+  const ih = Math.max(0, H - m.t - m.b);
 
   const n = series.labels.length;
   const maxY = Math.max(...series.cumMeta, ...series.cumReal) * 1.10 || 1;
@@ -1614,11 +2739,13 @@ function buildExecChart(container, series){
 
   const barW = Math.max(2, iw / (n*1.6));
 
+  const axisY = H - m.b;
+
   // grid Y
   const gy = [];
   for(let k=0;k<=4;k++){
     const val = (maxY/4)*k;
-    gy.push({ y: y(val), label: fmtBRL.format(Math.round(val)) });
+    gy.push({ y: y(val), label: formatBRLReadable(val) });
   }
 
   const path = (arr)=> arr.map((v,i)=> `${i?"L":"M"} ${x(i)} ${y(v)}`).join(" ");
@@ -1629,10 +2756,9 @@ function buildExecChart(container, series){
   const lineReal = `<path d="${path(series.cumReal)}" fill="none" stroke="#22c55e" stroke-width="2.5" />`;
   const lineMeta = `<path d="${path(series.cumMeta)}" fill="none" stroke="#60a5fa" stroke-width="2.5" stroke-dasharray="6 6" />`;
 
-  const pickIdx = (i)=> Math.min(n-1, Math.max(0, i));
-  const ticksX = [0, Math.floor(n*0.33), Math.floor(n*0.66), n-1].map(pickIdx);
-  const xlabels = [...new Set(ticksX)].map(i => 
-    `<text x="${x(i)}" y="${H-6}" font-size="10" text-anchor="middle" fill="#6b7280">${series.labels[i]}</text>`).join("");
+  const xlabels = series.labels.map((lab,i) =>
+    `<text x="${x(i)}" y="${axisY + 16}" font-size="9" text-anchor="middle" fill="#6b7280">${lab}</text>`
+  ).join("");
 
   const gridY = gy.map(g => 
     `<line x1="${m.l}" y1="${g.y}" x2="${W-m.r}" y2="${g.y}" stroke="#eef2f7"/>
@@ -1646,6 +2772,146 @@ function buildExecChart(container, series){
       ${bars}
       ${lineMeta}
       ${lineReal}
+      <line x1="${m.l}" y1="${axisY}" x2="${W-m.r}" y2="${axisY}" stroke="#e5e7eb"/>
+      ${xlabels}
+    </svg>`;
+}
+
+function monthKeyLabel(key){
+  if (!key) return "—";
+  const [y,m] = key.split('-');
+  const year = Number(y);
+  const month = Number(m);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return key;
+  const dt = new Date(Date.UTC(year, month - 1, 1));
+  return dt.toLocaleDateString("pt-BR", { month: "short", year: "numeric" }).replace(".", "");
+}
+
+function monthKeyFromDate(dt){
+  if (!(dt instanceof Date) || Number.isNaN(dt)) return "";
+  return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function normalizeMonthKey(value){
+  if (!value) return "";
+  if (value instanceof Date) return monthKeyFromDate(value);
+  if (typeof value === "string") {
+    const cleaned = value.trim().replace(/[\\/]/g, "-");
+    const match = cleaned.match(/^(\d{4})-(\d{2})/);
+    if (match) return `${match[1]}-${match[2]}`;
+  }
+  return "";
+}
+
+function makeMonthlySeries(rows, period){
+  const startISO = period?.start || todayISO();
+  const endISO = period?.end || startISO;
+
+  let startDate = dateUTCFromISO(startISO);
+  let endDate = dateUTCFromISO(endISO);
+  if (!startDate) startDate = dateUTCFromISO(todayISO());
+  if (!endDate) endDate = startDate;
+  if (startDate > endDate) [startDate, endDate] = [endDate, startDate];
+
+  const monthStart = new Date(startDate);
+  monthStart.setUTCDate(1);
+  const monthEnd = new Date(endDate);
+  monthEnd.setUTCDate(1);
+
+  const monthKeys = [];
+  const cursor = new Date(monthStart);
+  while (cursor <= monthEnd) {
+    monthKeys.push(monthKeyFromDate(cursor));
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+  }
+  const fallbackKey = monthKeys[0] || normalizeMonthKey(startISO) || normalizeMonthKey(todayISO()) || "";
+  if (!monthKeys.length && fallbackKey) monthKeys.push(fallbackKey);
+
+  const firstKey = monthKeys[0];
+  const lastKey = monthKeys[monthKeys.length - 1] || firstKey;
+  const buckets = new Map(monthKeys.map(key => [key, { meta:0, real:0 }]));
+
+  rows.forEach(r => {
+    const rawDate = r?.competencia || r?.mes || r?.data || r?.dataReferencia || r?.dt;
+    let key = normalizeMonthKey(rawDate);
+
+    if (!key && rawDate instanceof Date) {
+      key = monthKeyFromDate(rawDate);
+    }
+
+    if (!key && typeof rawDate === "string") {
+      const isoCandidate = rawDate.length >= 10 ? rawDate.slice(0, 10) : rawDate.length >= 7 ? `${rawDate.slice(0,7)}-01` : "";
+      key = normalizeMonthKey(isoCandidate);
+    }
+
+    if (!key) key = fallbackKey;
+    if (!key) return;
+
+    if (firstKey && key < firstKey) return;
+    if (lastKey && key > lastKey) return;
+
+    if (!buckets.has(key)) buckets.set(key, { meta:0, real:0 });
+    const agg = buckets.get(key);
+    agg.meta += (r.meta_mens ?? r.meta ?? 0);
+    agg.real += (r.real_mens ?? r.realizado ?? 0);
+  });
+
+  const ordered = [...buckets.entries()].sort((a,b)=> a[0].localeCompare(b[0]));
+  return {
+    labels: ordered.map(([key])=> monthKeyLabel(key)),
+    meta:   ordered.map(([,v])=> v.meta),
+    real:   ordered.map(([,v])=> v.real)
+  };
+}
+
+function buildExecMonthlyChart(container, series){
+  const { width: W, height: H } = chartDimensions(container);
+  const m = { t:20, r:20, b:42, l:64 };
+  const iw = Math.max(0, W - m.l - m.r);
+  const ih = Math.max(0, H - m.t - m.b);
+  const maxY = Math.max(...series.meta, ...series.real) * 1.1 || 1;
+  const n = series.labels.length;
+  const band = iw / Math.max(1, n);
+  const gap = Math.min(18, band * 0.25);
+  const barW = Math.max(18, band - gap);
+  const realW = Math.max(10, barW * 0.6);
+  const offset = (barW - realW) / 2;
+
+  const xBase = i => m.l + band * i + gap/2;
+  const y = v => m.t + ih - (v / maxY) * ih;
+
+  const baseColor = "#2563eb";
+  const barsMeta = series.meta.map((v,i)=> {
+    const height = Math.max(0, y(0) - y(v));
+    return `<rect x="${xBase(i)}" y="${y(v)}" width="${barW}" height="${height}" fill="none" stroke="${baseColor}" stroke-width="1.6" stroke-dasharray="4 3" stroke-opacity="0.7" rx="2"/>`;
+  }).join("");
+  const barsReal = series.real.map((v,i)=> {
+    const height = Math.max(0, y(0) - y(v));
+    return `<rect x="${xBase(i)+offset}" y="${y(v)}" width="${realW}" height="${height}" fill="${baseColor}" fill-opacity="0.7" stroke="${baseColor}" stroke-width="1.4" rx="2"/>`;
+  }).join("");
+
+  const gy = [];
+  for(let k=0;k<=4;k++){
+    const val = (maxY/4)*k;
+    gy.push({ y: y(val), label: formatBRLReadable(val) });
+  }
+
+  const gridY = gy.map(g =>
+    `<line x1="${m.l}" y1="${g.y}" x2="${W-m.r}" y2="${g.y}" stroke="#eef2f7"/>
+     <text x="${m.l-6}" y="${g.y+3}" font-size="10" text-anchor="end" fill="#6b7280">${g.label}</text>`
+  ).join("");
+
+  const xlabels = series.labels.map((lab,i)=> {
+    const cx = m.l + band * i + band/2;
+    return `<text x="${cx}" y="${H-6}" font-size="10" text-anchor="middle" fill="#6b7280">${lab}</text>`;
+  }).join("");
+
+  container.innerHTML = `
+    <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" role="img" aria-label="barras mensais de meta e realizado">
+      <rect x="0" y="0" width="${W}" height="${H}" fill="white"/>
+      ${gridY}
+      ${barsMeta}
+      ${barsReal}
       <line x1="${m.l}" y1="${H-m.b}" x2="${W-m.r}" y2="${H-m.b}" stroke="#e5e7eb"/>
       ${xlabels}
     </svg>`;
@@ -1659,9 +2925,11 @@ function renderExecutiveView(){
   const ctx    = document.getElementById("exec-context");
   const kpis   = document.getElementById("exec-kpis");
   const chartC = document.getElementById("exec-chart");
+  const chartTitleEl = document.getElementById("exec-chart-title");
+  const chartLegend = document.getElementById("exec-chart-legend");
+  const chartToggle = document.getElementById("exec-chart-toggle");
   const hm     = document.getElementById("exec-heatmap");
   const rankEl = document.getElementById("exec-rank");
-  const ritmo  = document.getElementById("exec-ritmo");
   const statusList = document.getElementById("exec-status-list");
 
   if (!Array.isArray(state._rankingRaw) || !state._rankingRaw.length){
@@ -1671,6 +2939,14 @@ function renderExecutiveView(){
 
   // base com TODOS os filtros aplicados
   const rowsBase = filterRows(state._rankingRaw);
+
+  const chartMode = state.exec?.chartMode || "diario";
+  if (chartToggle){
+    chartToggle.querySelectorAll('.seg-btn').forEach(btn=>{
+      const mode = btn.dataset.chart || "diario";
+      btn.classList.toggle('is-active', mode === chartMode);
+    });
+  }
 
   // nível inicial
   const start = execStartLevelFromFilters();
@@ -1712,10 +2988,19 @@ function renderExecutiveView(){
   const forecastPct    = total.meta_mens ? (forecast/total.meta_mens)*100 : 0;
 
   if (kpis){
+    const realMensFull = fmtBRL.format(Math.round(total.real_mens));
+    const realMensDisplay = formatBRLReadable(total.real_mens);
+    const metaMensFull = fmtBRL.format(Math.round(total.meta_mens));
+    const metaMensDisplay = formatBRLReadable(total.meta_mens);
+    const defasFull = fmtBRL.format(Math.round(defas));
+    const defasDisplay = formatBRLReadable(defas);
+    const forecastFull = fmtBRL.format(Math.round(forecast));
+    const forecastDisplay = formatBRLReadable(forecast);
+
     kpis.innerHTML = `
       <div class="kpi-card">
         <div class="kpi-card__title">Atingimento mensal</div>
-        <div class="kpi-card__value">${fmtBRL.format(total.real_mens)} <small>/ ${fmtBRL.format(total.meta_mens)}</small></div>
+        <div class="kpi-card__value"><span title="${realMensFull}">${realMensDisplay}</span> <small>/ <span title="${metaMensFull}">${metaMensDisplay}</span></small></div>
         <div class="kpi-card__bar">
           <div class="kpi-card__fill ${pctBadgeCls(ating*100)}" style="width:${Math.min(100, Math.max(0, ating*100))}%"></div>
         </div>
@@ -1724,13 +3009,13 @@ function renderExecutiveView(){
 
       <div class="kpi-card">
         <div class="kpi-card__title">Defasagem do mês</div>
-        <div class="kpi-card__value ${moneyBadgeCls(defas)}">${fmtBRL.format(defas)}</div>
+        <div class="kpi-card__value ${moneyBadgeCls(defas)}" title="${defasFull}">${defasDisplay}</div>
         <div class="kpi-sub muted">Real – Meta (mês)</div>
       </div>
 
       <div class="kpi-card">
         <div class="kpi-card__title">Forecast x Meta</div>
-        <div class="kpi-card__value">${fmtBRL.format(Math.round(forecast))} <small>/ ${fmtBRL.format(total.meta_mens)}</small></div>
+        <div class="kpi-card__value"><span title="${forecastFull}">${forecastDisplay}</span> <small>/ <span title="${metaMensFull}">${metaMensDisplay}</span></small></div>
         <div class="kpi-card__bar">
           <div class="kpi-card__fill ${pctBadgeCls(forecastPct)}" style="width:${Math.min(100, Math.max(0, forecastPct))}%"></div>
         </div>
@@ -1740,8 +3025,36 @@ function renderExecutiveView(){
 
   // Gráfico
   if (chartC){
-    const series = makeDailySeries(total.meta_mens, total.real_mens, state.period.start, state.period.end);
-    buildExecChart(chartC, series);
+    const renderChart = () => {
+      const mode = state.exec?.chartMode || "diario";
+      if (mode === "mensal"){
+        const monthlySeries = makeMonthlySeries(rowsBase, state.period);
+        buildExecMonthlyChart(chartC, monthlySeries);
+        chartC.setAttribute("aria-label", "Comparativo mensal de meta e realizado em barras azuis");
+        if (chartTitleEl) chartTitleEl.textContent = "Evolução mensal";
+        if (chartLegend){
+          chartLegend.innerHTML = `
+            <span class="legend-item"><span class="legend-swatch legend-swatch--monthly-meta"></span>Meta mensal (contorno)</span>
+            <span class="legend-item"><span class="legend-swatch legend-swatch--monthly-real"></span>Realizado mensal (barra)</span>
+          `;
+        }
+      } else {
+        const dailySeries = makeDailySeries(total.meta_mens, total.real_mens, state.period.start, state.period.end);
+        buildExecChart(chartC, dailySeries);
+        chartC.setAttribute("aria-label", "Evolução diária com linhas de meta e realizado");
+        if (chartTitleEl) chartTitleEl.textContent = "Evolução do mês";
+        if (chartLegend){
+          chartLegend.innerHTML = `
+            <span class="legend-item"><span class="legend-swatch legend-swatch--bars"></span>Diário realizado (barras)</span>
+            <span class="legend-item"><span class="legend-swatch legend-swatch--real"></span>Realizado acumulado (linha)</span>
+            <span class="legend-item"><span class="legend-swatch legend-swatch--meta"></span>Meta acumulada (linha)</span>
+          `;
+        }
+      }
+    };
+
+    renderChart();
+    host.__execChartRender = renderChart;
 
     // redimensiona enquanto essa aba estiver ativa
     if (!host.__execResize){
@@ -1749,7 +3062,8 @@ function renderExecutiveView(){
       host.__execResize = () => {
         if (state.activeView !== 'exec') return;
         if (raf) cancelAnimationFrame(raf);
-        raf = requestAnimationFrame(()=> buildExecChart(chartC, series));
+        const fn = host.__execChartRender;
+        raf = requestAnimationFrame(()=> fn && fn());
       };
       window.addEventListener('resize', host.__execResize);
     }
@@ -1757,14 +3071,19 @@ function renderExecutiveView(){
 
   // Ranking Top/Bottom para o nível atual
   const grouped = execAggBy(rowsBase, startKey).sort((a,b)=> b.p_mens - a.p_mens);
-  const renderRankRows = (arr)=> arr.map(r=>`
+  const renderRankRows = (arr)=> arr.map(r=>{
+    const realFull = fmtBRL.format(Math.round(r.real_mens));
+    const realDisplay = formatBRLReadable(r.real_mens);
+    const metaFull = fmtBRL.format(Math.round(r.meta_mens));
+    const metaDisplay = formatBRLReadable(r.meta_mens);
+    return `
     <div class="rank-mini__row" data-key="${r.key}">
       <div class="rank-mini__name">${r.key}</div>
       <div class="rank-mini__bar"><span style="width:${Math.min(100,Math.max(0,r.p_mens))}%"></span></div>
       <div class="rank-mini__pct"><span class="att-badge ${pctBadgeCls(r.p_mens)}">${r.p_mens.toFixed(1)}%</span></div>
-      <div class="rank-mini__vals"><strong>${fmtBRL.format(r.real_mens)}</strong> <small>/ ${fmtBRL.format(r.meta_mens)}</small></div>
-    </div>
-  `).join("");
+      <div class="rank-mini__vals"><strong title="${realFull}">${realDisplay}</strong> <small title="${metaFull}">/ ${metaDisplay}</small></div>
+    </div>`;
+  }).join("");
 
   if (rankEl){
     if (state.exec.rankMode === "bottom"){
@@ -1794,27 +3113,6 @@ function renderExecutiveView(){
         document.querySelector('.tab[data-view="table"]')?.click();
       });
     });
-  }
-
-  // Ritmo
-  if (ritmo){
-    const ritmoOk = mediaDiaria >= necessarioDia && total.real_mens < total.meta_mens ? "ok" : (mediaDiaria>=necessarioDia ? "ok" : "warn");
-    ritmo.innerHTML = `
-      <div class="ritmo-grid">
-        <div class="ritmo-box">
-          <div class="ritmo-label">Média/dia atual</div>
-          <div class="ritmo-val">${fmtBRL.format(Math.round(mediaDiaria))}</div>
-          <div class="ritmo-bar"><span style="width:100%"></span></div>
-        </div>
-        <div class="ritmo-box">
-          <div class="ritmo-label">Necessário/dia</div>
-          <div class="ritmo-val">${fmtBRL.format(Math.round(necessarioDia))}</div>
-          <div class="ritmo-bar ritmo-need"><span style="width:100%"></span></div>
-        </div>
-        <div class="ritmo-note ${ritmoOk==='ok'?'pos':'neg'}">
-          ${ritmoOk==='ok' ? 'No ritmo para bater a meta.' : 'Abaixo do ritmo — ajuste necessário.'}
-        </div>
-      </div>`;
   }
 
   // Heatmap — (start) × Família
@@ -1917,6 +3215,621 @@ function renderExecutiveView(){
 }
 
 /* ===== Ranking ===== */
+/* ===== Campanhas ===== */
+function currentSprintConfig(){
+  if (!Array.isArray(CAMPAIGN_SPRINTS) || !CAMPAIGN_SPRINTS.length) return null;
+  const id = state.campanhas?.sprintId;
+  return CAMPAIGN_SPRINTS.find(s => s.id === id) || CAMPAIGN_SPRINTS[0];
+}
+
+function ensureCampanhasView(){
+  const host = document.getElementById("view-campanhas");
+  if (!host) return;
+  if (!CAMPAIGN_SPRINTS.length) {
+    host.innerHTML = `<section class="card card--campanhas"><p class="muted">Nenhuma campanha disponível.</p></section>`;
+    return;
+  }
+
+  const select = document.getElementById("campanha-sprint");
+  if (select && !select.dataset.bound) {
+    select.dataset.bound = "1";
+    select.addEventListener("change", (ev) => {
+      state.campanhas.sprintId = ev.target.value;
+      renderCampanhasView();
+    });
+  }
+}
+
+function ensureTeamValuesForSprint(sprint){
+  if (!sprint || !state.campanhas) return {};
+  const store = state.campanhas.teamValues;
+  if (!store[sprint.id]) {
+    const base = {};
+    (sprint.team?.indicators || []).forEach(ind => {
+      base[ind.id] = toNumber(ind.default ?? 100);
+    });
+    store[sprint.id] = base;
+    const defaultPreset = sprint.team?.defaultPreset || (sprint.team?.presets?.[0]?.id || "custom");
+    state.campanhas.teamPreset[sprint.id] = defaultPreset;
+  }
+  return store[sprint.id];
+}
+
+function ensureIndividualValuesForProfile(sprint, profile){
+  if (!sprint || !profile || !state.campanhas) return {};
+  const bySprint = state.campanhas.individualValues[sprint.id] || (state.campanhas.individualValues[sprint.id] = {});
+  if (!bySprint[profile.id]) {
+    const base = {};
+    (profile.indicators || []).forEach(ind => {
+      base[ind.id] = toNumber(ind.default ?? 100);
+    });
+    bySprint[profile.id] = base;
+    const key = `${sprint.id}:${profile.id}`;
+    const defaultPreset = profile.defaultPreset || (profile.presets?.[0]?.id || "custom");
+    state.campanhas.individualPreset[key] = defaultPreset;
+  }
+  return bySprint[profile.id];
+}
+
+function detectPresetMatch(values, presets){
+  if (!values || !Array.isArray(presets)) return null;
+  return presets.find(preset => {
+    const pairs = Object.entries(preset.values || {});
+    return pairs.every(([key, val]) => Math.round(toNumber(val)) === Math.round(toNumber(values[key])));
+  })?.id || null;
+}
+
+function formatCampPoints(value){
+  return `${fmtONE.format(toNumber(value))} pts`;
+}
+
+function formatCampPercent(value){
+  return `${fmtONE.format(toNumber(value))}%`;
+}
+
+function computeCampaignScore(config, values){
+  const indicators = config?.indicators || [];
+  const min = toNumber(config?.minThreshold ?? 90);
+  const stretch = toNumber(config?.superThreshold ?? (min + 20));
+  const cap = toNumber(config?.cap ?? 150);
+  const minTotal = toNumber(config?.eligibilityMinimum ?? 100) || 100;
+
+  const rows = indicators.map(ind => {
+    const raw = Math.max(0, toNumber(values?.[ind.id] ?? ind.default ?? 0));
+    const capped = Math.min(cap, raw);
+    const points = (toNumber(ind.weight) * capped) / 100;
+    let statusText = "Crítico";
+    let statusClass = "status-pill--alert";
+    if (raw >= stretch) {
+      statusText = "Parabéns";
+      statusClass = "status-pill--great";
+    } else if (raw >= min) {
+      statusText = "Elegível";
+      statusClass = "status-pill--ok";
+    } else if (raw >= Math.max(0, min - 10)) {
+      statusText = "Ajustar";
+      statusClass = "status-pill--warn";
+    }
+    return { ...ind, pct: raw, capped, points, statusText, statusClass };
+  });
+
+  const totalPoints = rows.reduce((acc, row) => acc + row.points, 0);
+  const hasAllMin = rows.every(row => row.pct >= min);
+  const hasAllStretch = rows.every(row => row.pct >= stretch);
+  const eligible = hasAllMin && totalPoints >= minTotal;
+
+  let finalStatus = "Não elegível";
+  let finalClass = "status-tag--alert";
+  if (hasAllStretch && totalPoints >= minTotal) {
+    finalStatus = "Parabéns";
+    finalClass = "status-tag--great";
+  } else if (eligible) {
+    finalStatus = "Elegível";
+    finalClass = "status-tag--ok";
+  } else if (hasAllMin) {
+    finalStatus = "Ajustar foco";
+    finalClass = "status-tag--warn";
+  }
+
+  const shortfall = Math.max(0, minTotal - totalPoints);
+  const progressPct = minTotal ? Math.max(0, Math.min(1, totalPoints / minTotal)) : 0;
+  const progressLabel = shortfall > 0
+    ? `${fmtONE.format(shortfall)} pts para elegibilidade`
+    : (hasAllStretch ? "Acima do stretch" : "Meta mínima atingida");
+
+  return { rows, totalPoints, finalStatus, finalClass, progressPct, progressLabel, shortfall, hasAllMin, hasAllStretch, minThreshold: min, superThreshold: stretch, cap, eligibilityMinimum: minTotal };
+}
+
+function teamPresetForSprint(sprint){
+  return state.campanhas.teamPreset[sprint.id] || "custom";
+}
+
+function setTeamPresetForSprint(sprint, presetId){
+  state.campanhas.teamPreset[sprint.id] = presetId || "custom";
+}
+
+function individualPresetKey(sprint, profile){
+  return `${sprint.id}:${profile.id}`;
+}
+
+function individualPresetForProfile(sprint, profile){
+  return state.campanhas.individualPreset[individualPresetKey(sprint, profile)] || "custom";
+}
+
+function setIndividualPresetForProfile(sprint, profile, presetId){
+  state.campanhas.individualPreset[individualPresetKey(sprint, profile)] = presetId || "custom";
+}
+
+function buildTeamSimulator(container, sprint){
+  if (!container || !sprint?.team) return;
+  if (container.dataset.sprintId === sprint.id) return;
+  container.dataset.sprintId = sprint.id;
+
+  const indicators = sprint.team.indicators || [];
+  const presets = sprint.team.presets || [];
+
+  container.innerHTML = `
+    <div class="sim-card__head">
+      <div class="sim-card__title">
+        <h5>Simulador de equipe</h5>
+        <button type="button" class="sim-help" aria-label="Como funciona o simulador de equipe" data-tip="Ajuste os percentuais de cada indicador entre 0% e 150%. A equipe se torna elegível com todos os indicadores a partir de 90% e somando pelo menos 100 pontos.">
+          <i class="ti ti-info-circle"></i>
+        </button>
+      </div>
+      <p>Defina o atingimento de cada indicador para estimar a pontuação e a elegibilidade da equipe.</p>
+      <p class="sim-hint">Elegível com todos os indicadores ≥ 90% e pelo menos 100 pontos.</p>
+    </div>
+    <div class="sim-presets" id="team-presets">
+      ${presets.map(p => `<button type="button" class="sim-chip" data-team-preset="${p.id}">${p.label}</button>`).join("")}
+    </div>
+    <table class="sim-table">
+      <thead>
+        <tr>
+          <th>Indicador</th>
+          <th>Peso</th>
+          <th>Atingimento</th>
+          <th>Pontos</th>
+          <th>Resultado</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${indicators.map(ind => `
+          <tr data-row="${ind.id}">
+            <td class="sim-indicator" data-label="Indicador">
+              <strong>${ind.label}</strong>
+              ${ind.hint ? `<div class="muted" style="font-size:12px;">${ind.hint}</div>` : ""}
+            </td>
+            <td class="sim-weight" data-label="Peso">${fmtONE.format(toNumber(ind.weight))}%</td>
+            <td data-label="Atingimento">
+              <div class="sim-slider">
+                <input type="range" min="0" max="160" step="1" data-indicator="${ind.id}" aria-label="${ind.label}" />
+                <span class="sim-slider-value" data-output="${ind.id}"></span>
+              </div>
+            </td>
+            <td class="sim-points" data-label="Pontos" data-points="${ind.id}"></td>
+            <td data-label="Resultado"><span class="status-pill" data-status="${ind.id}"></span></td>
+          </tr>
+        `).join("")}
+      </tbody>
+    </table>
+    <div class="sim-summary">
+      <div class="sim-total">
+        <span>Pontuação total</span>
+        <strong id="team-total-points"></strong>
+      </div>
+      <div class="sim-progress">
+        <div class="sim-progress__track"><span id="team-progress-bar"></span></div>
+        <small id="team-progress-label"></small>
+      </div>
+      <div class="sim-outcome">
+        <span id="team-status" class="status-tag"></span>
+      </div>
+    </div>
+  `;
+
+  container.querySelectorAll("input[type=range]").forEach(input => {
+    input.addEventListener("input", (ev) => {
+      const id = ev.currentTarget.dataset.indicator;
+      const values = ensureTeamValuesForSprint(sprint);
+      values[id] = toNumber(ev.currentTarget.value);
+      updateTeamSimulator(container, sprint);
+    });
+  });
+
+  container.querySelectorAll("[data-team-preset]").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const presetId = btn.dataset.teamPreset;
+      const preset = presets.find(p => p.id === presetId);
+      if (!preset) return;
+      const values = ensureTeamValuesForSprint(sprint);
+      Object.entries(preset.values || {}).forEach(([key, val]) => {
+        values[key] = toNumber(val);
+      });
+      setTeamPresetForSprint(sprint, presetId);
+      updateTeamSimulator(container, sprint);
+    });
+  });
+}
+
+function updateTeamSimulator(container, sprint){
+  if (!container || !sprint?.team) return;
+  const values = ensureTeamValuesForSprint(sprint);
+  const result = computeCampaignScore(sprint.team, values);
+
+  (sprint.team.indicators || []).forEach(ind => {
+    const row = container.querySelector(`tr[data-row="${ind.id}"]`);
+    if (!row) return;
+    const slider = row.querySelector("input[type=range]");
+    if (slider && slider.value !== String(values[ind.id])) slider.value = String(values[ind.id]);
+    const output = row.querySelector(`[data-output="${ind.id}"]`);
+    if (output) output.textContent = formatCampPercent(values[ind.id] ?? 0);
+    const pointsCell = row.querySelector(`[data-points="${ind.id}"]`);
+    const rowData = result.rows.find(r => r.id === ind.id);
+    if (pointsCell && rowData) pointsCell.textContent = formatCampPoints(rowData.points);
+    const statusEl = row.querySelector(`[data-status="${ind.id}"]`);
+    if (statusEl && rowData) {
+      statusEl.textContent = rowData.statusText;
+      statusEl.className = `status-pill ${rowData.statusClass}`;
+    }
+  });
+
+  const presetMatch = detectPresetMatch(values, sprint.team.presets);
+  setTeamPresetForSprint(sprint, presetMatch || "custom");
+  const activePreset = teamPresetForSprint(sprint);
+  container.querySelectorAll("[data-team-preset]").forEach(btn => {
+    btn.classList.toggle("is-active", btn.dataset.teamPreset === activePreset);
+  });
+
+  const totalEl = container.querySelector("#team-total-points");
+  if (totalEl) totalEl.textContent = formatCampPoints(result.totalPoints);
+  const statusEl = container.querySelector("#team-status");
+  if (statusEl) {
+    statusEl.textContent = result.finalStatus;
+    statusEl.className = `status-tag ${result.finalClass}`;
+  }
+  const progressBar = container.querySelector("#team-progress-bar");
+  if (progressBar) progressBar.style.width = `${Math.round(result.progressPct * 100)}%`;
+  const progressLabel = container.querySelector("#team-progress-label");
+  if (progressLabel) progressLabel.textContent = result.progressLabel;
+}
+
+function buildIndividualSimulator(container, sprint, profile){
+  if (!container || !sprint || !profile) return;
+  const key = `${sprint.id}:${profile.id}`;
+  if (container.dataset.profileKey === key) return;
+  container.dataset.profileKey = key;
+
+  const profiles = sprint.individual?.profiles || [];
+  const presets = profile.presets || [];
+
+  container.innerHTML = `
+    <div class="sim-card__head">
+      <div class="sim-card__title">
+        <h5>Simulador individual</h5>
+        <button type="button" class="sim-help" aria-label="Como funciona o simulador individual" data-tip="Escolha um perfil, use os presets ou ajuste manualmente. Para elegibilidade é necessário atingir 90% em cada indicador e acumular 100 pontos ou mais.">
+          <i class="ti ti-info-circle"></i>
+        </button>
+      </div>
+      <p>Simule o desempenho de um gerente considerando os mesmos pesos da campanha.</p>
+      <p id="individual-description" class="sim-hint">${profile.description || ""}</p>
+    </div>
+    <div class="segmented seg-mini" role="tablist" id="individual-profiles">
+      ${profiles.map(p => `<button type="button" class="seg-btn" data-profile="${p.id}">${p.label}</button>`).join("")}
+    </div>
+    <div class="sim-presets" id="individual-presets">
+      ${presets.map(p => `<button type="button" class="sim-chip" data-individual-preset="${p.id}">${p.label}</button>`).join("")}
+    </div>
+    <table class="sim-table">
+      <thead>
+        <tr>
+          <th>Indicador</th>
+          <th>Peso</th>
+          <th>Atingimento</th>
+          <th>Pontos</th>
+          <th>Resultado</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${(profile.indicators || []).map(ind => `
+          <tr data-row="${ind.id}">
+            <td class="sim-indicator" data-label="Indicador">
+              <strong>${ind.label}</strong>
+            </td>
+            <td class="sim-weight" data-label="Peso">${fmtONE.format(toNumber(ind.weight))}%</td>
+            <td data-label="Atingimento">
+              <div class="sim-slider">
+                <input type="range" min="0" max="160" step="1" data-indicator="${ind.id}" aria-label="${ind.label}" />
+                <span class="sim-slider-value" data-output="${ind.id}"></span>
+              </div>
+            </td>
+            <td class="sim-points" data-label="Pontos" data-points="${ind.id}"></td>
+            <td data-label="Resultado"><span class="status-pill" data-status="${ind.id}"></span></td>
+          </tr>
+        `).join("")}
+      </tbody>
+    </table>
+    <div class="sim-summary">
+      <div class="sim-total">
+        <span>Pontuação total</span>
+        <strong id="individual-total-points"></strong>
+      </div>
+      <div class="sim-progress">
+        <div class="sim-progress__track"><span id="individual-progress-bar"></span></div>
+        <small id="individual-progress-label"></small>
+      </div>
+      <div class="sim-outcome">
+        <span id="individual-status" class="status-tag"></span>
+      </div>
+    </div>
+  `;
+
+  container.querySelectorAll("#individual-profiles .seg-btn").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const profileId = btn.dataset.profile;
+      if (!profileId) return;
+      state.campanhas.individualProfile = profileId;
+      renderCampanhasView();
+    });
+  });
+
+  container.querySelectorAll("input[type=range]").forEach(input => {
+    input.addEventListener("input", (ev) => {
+      const id = ev.currentTarget.dataset.indicator;
+      const values = ensureIndividualValuesForProfile(sprint, profile);
+      values[id] = toNumber(ev.currentTarget.value);
+      updateIndividualSimulator(container, sprint, profile);
+    });
+  });
+
+  container.querySelectorAll("[data-individual-preset]").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const presetId = btn.dataset.individualPreset;
+      const preset = presets.find(p => p.id === presetId);
+      if (!preset) return;
+      const values = ensureIndividualValuesForProfile(sprint, profile);
+      Object.entries(preset.values || {}).forEach(([key, val]) => {
+        values[key] = toNumber(val);
+      });
+      setIndividualPresetForProfile(sprint, profile, presetId);
+      updateIndividualSimulator(container, sprint, profile);
+    });
+  });
+
+}
+
+function updateIndividualSimulator(container, sprint, profile){
+  if (!container || !sprint || !profile) return;
+  const values = ensureIndividualValuesForProfile(sprint, profile);
+  const result = computeCampaignScore(profile, values);
+
+  container.querySelectorAll("#individual-profiles .seg-btn").forEach(btn => {
+    btn.classList.toggle("is-active", btn.dataset.profile === profile.id);
+  });
+
+  const desc = container.querySelector("#individual-description");
+  if (desc) desc.textContent = profile.description || "";
+
+  (profile.indicators || []).forEach(ind => {
+    const row = container.querySelector(`tr[data-row="${ind.id}"]`);
+    if (!row) return;
+    const slider = row.querySelector("input[type=range]");
+    if (slider && slider.value !== String(values[ind.id])) slider.value = String(values[ind.id]);
+    const output = row.querySelector(`[data-output="${ind.id}"]`);
+    if (output) output.textContent = formatCampPercent(values[ind.id] ?? 0);
+    const rowData = result.rows.find(r => r.id === ind.id);
+    const pointsCell = row.querySelector(`[data-points="${ind.id}"]`);
+    if (pointsCell && rowData) pointsCell.textContent = formatCampPoints(rowData.points);
+    const statusEl = row.querySelector(`[data-status="${ind.id}"]`);
+    if (statusEl && rowData) {
+      statusEl.textContent = rowData.statusText;
+      statusEl.className = `status-pill ${rowData.statusClass}`;
+    }
+  });
+
+  const presetMatch = detectPresetMatch(values, profile.presets);
+  setIndividualPresetForProfile(sprint, profile, presetMatch || "custom");
+  const activePreset = individualPresetForProfile(sprint, profile);
+  container.querySelectorAll("[data-individual-preset]").forEach(btn => {
+    btn.classList.toggle("is-active", btn.dataset.individualPreset === activePreset);
+  });
+
+  const totalEl = container.querySelector("#individual-total-points");
+  if (totalEl) totalEl.textContent = formatCampPoints(result.totalPoints);
+  const statusEl = container.querySelector("#individual-status");
+  if (statusEl) {
+    statusEl.textContent = result.finalStatus;
+    statusEl.className = `status-tag ${result.finalClass}`;
+  }
+  const progressBar = container.querySelector("#individual-progress-bar");
+  if (progressBar) progressBar.style.width = `${Math.round(result.progressPct * 100)}%`;
+  const progressLabel = container.querySelector("#individual-progress-label");
+  if (progressLabel) progressLabel.textContent = result.progressLabel;
+
+}
+
+function badgeClassFromStatus(status){
+  const norm = (status || "").toLowerCase();
+  if (norm.includes("parab")) return "elegibility-badge elegibility-badge--great";
+  if (norm.includes("não") || norm.includes("nao")) return "elegibility-badge elegibility-badge--warn";
+  if (norm.includes("ajust")) return "elegibility-badge elegibility-badge--warn";
+  return "elegibility-badge elegibility-badge--ok";
+}
+
+function renderCampaignRanking(container, sprint, options = {}){
+  if (!container) return;
+  const rows = options.rows || [];
+  if (!rows.length) {
+    container.innerHTML = `<p class="muted">Nenhum resultado disponível.</p>`;
+    return;
+  }
+
+  const columnLabel = options.columnLabel || "Unidade";
+  const config = sprint.team;
+  const body = rows.map((row, idx) => {
+    const result = row.result || computeCampaignScore(config, { linhas: row.linhas, cash: row.cash, conquista: row.conquista });
+    const linhas = result.rows.find(r => r.id === "linhas");
+    const cash = result.rows.find(r => r.id === "cash");
+    const conquista = result.rows.find(r => r.id === "conquista");
+    const badgeClass = badgeClassFromStatus(row.finalStatus || result.finalStatus);
+    const rank = row.rank != null ? row.rank : (idx + 1);
+    return `
+      <tr>
+        <td class="pos-col">${rank}</td>
+        <td class="regional-col">${row.name || "—"}</td>
+        <td>
+          <div class="indicator-bar">
+            <div class="indicator-bar__track"><span style="width:${Math.min(100, (linhas?.capped || 0) / (config?.cap || 150) * 100)}%"></span></div>
+            <div class="indicator-bar__value">${formatCampPercent(row.linhas)}</div>
+          </div>
+          <div class="indicator-bar__points">${formatCampPoints(linhas?.points || 0)}</div>
+        </td>
+        <td>
+          <div class="indicator-bar">
+            <div class="indicator-bar__track"><span style="width:${Math.min(100, (cash?.capped || 0) / (config?.cap || 150) * 100)}%"></span></div>
+            <div class="indicator-bar__value">${formatCampPercent(row.cash)}</div>
+          </div>
+          <div class="indicator-bar__points">${formatCampPoints(cash?.points || 0)}</div>
+        </td>
+        <td>
+          <div class="indicator-bar">
+            <div class="indicator-bar__track"><span style="width:${Math.min(100, (conquista?.capped || 0) / (config?.cap || 150) * 100)}%"></span></div>
+            <div class="indicator-bar__value">${formatCampPercent(row.conquista)}</div>
+          </div>
+          <div class="indicator-bar__points">${formatCampPoints(conquista?.points || 0)}</div>
+        </td>
+        <td>${formatCampPoints(result.totalPoints)}</td>
+        <td>${row.atividade ? "Sim" : "Não"}</td>
+        <td><span class="${badgeClass}">${row.finalStatus || result.finalStatus}</span></td>
+      </tr>`;
+  }).join("");
+
+  container.innerHTML = `
+    <table class="camp-ranking-table">
+      <thead>
+        <tr>
+          <th class="pos-col">#</th>
+          <th class="regional-col">${columnLabel}</th>
+          <th>Linhas governamentais</th>
+          <th>Cash (TPV)</th>
+          <th>Abertura de contas</th>
+          <th>Pontuação final</th>
+          <th>Atividade comercial</th>
+          <th>Elegibilidade</th>
+        </tr>
+      </thead>
+      <tbody>${body}</tbody>
+    </table>`;
+}
+
+function renderCampanhasView(){
+  const host = document.getElementById("view-campanhas");
+  if (!host) return;
+  if (!Array.isArray(CAMPAIGN_SPRINTS) || !CAMPAIGN_SPRINTS.length) return;
+
+  const sprint = currentSprintConfig();
+  if (!sprint) return;
+
+  const rankingContext = buildCampaignRankingContext(sprint);
+  const summaryInfo = summarizeCampaignUnitResults(rankingContext.unitResults);
+  const aggregatedRows = rankingContext.aggregated.slice().sort((a, b) => b.totalPoints - a.totalPoints);
+  aggregatedRows.forEach((row, idx) => { row.rank = idx + 1; });
+
+  const select = document.getElementById("campanha-sprint");
+  if (select) {
+    select.innerHTML = CAMPAIGN_SPRINTS.map(sp => `<option value="${sp.id}">${sp.label}</option>`).join("");
+    select.value = sprint.id;
+  }
+
+  const cycleEl = document.getElementById("camp-cycle");
+  if (cycleEl) cycleEl.textContent = sprint.cycle || "";
+
+  const noteEl = document.getElementById("camp-note");
+  if (noteEl) {
+    const metaInfo = rankingContext.levelInfo?.meta;
+    const pluralLabel = metaInfo?.plural || "unidades";
+    const visibleUnits = aggregatedRows.length;
+    const base = sprint.note || "";
+    const suffix = visibleUnits
+      ? ` Exibindo ${fmtINT.format(visibleUnits)} ${pluralLabel} filtradas.`
+      : " Nenhuma unidade encontrada para o filtro atual.";
+    noteEl.textContent = `${base}${suffix}`.trim();
+  }
+
+  const periodEl = document.getElementById("camp-period");
+  if (periodEl) {
+    const start = sprint.period?.start ? formatBRDate(sprint.period.start) : "";
+    const end = sprint.period?.end ? formatBRDate(sprint.period.end) : "";
+    periodEl.textContent = start && end ? `De ${start} até ${end}` : "Período não informado";
+  }
+
+  const headline = document.getElementById("camp-headline");
+  if (headline) {
+    headline.innerHTML = (sprint.headStats || []).map(stat => `
+      <div class="camp-hero__stat">
+        <span>${stat.label}</span>
+        <strong>${stat.value}</strong>
+        ${stat.sub ? `<small>${stat.sub}</small>` : ""}
+      </div>`).join("");
+  }
+
+  const kpiGrid = document.getElementById("camp-kpis");
+  if (kpiGrid) {
+    const summaryData = (sprint.summary || []).map(item => {
+      if (item.id === "equipes") {
+        return { ...item, value: summaryInfo.elegiveis, total: summaryInfo.total };
+      }
+      if (item.id === "media") {
+        return { ...item, value: summaryInfo.media };
+      }
+      if (item.id === "recorde") {
+        return { ...item, value: summaryInfo.recorde, complement: summaryInfo.destaque || item.complement || "" };
+      }
+      return item;
+    });
+
+    kpiGrid.innerHTML = summaryData.map(item => {
+      if (item.total != null) {
+        return `<div class="camp-kpi"><span>${item.label}</span><strong>${fmtINT.format(item.value)} / ${fmtINT.format(item.total)}</strong><small>de ${fmtINT.format(item.total)} monitoradas</small></div>`;
+      }
+      if (item.unit === "pts") {
+        return `<div class="camp-kpi"><span>${item.label}</span><strong>${formatCampPoints(item.value)}</strong>${item.complement ? `<small>${item.complement}</small>` : ""}</div>`;
+      }
+      if (item.text) {
+        return `<div class="camp-kpi"><span>${item.label}</span><strong>${item.text}</strong></div>`;
+      }
+      return `<div class="camp-kpi"><span>${item.label}</span><strong>${fmtONE.format(item.value)}</strong>${item.complement ? `<small>${item.complement}</small>` : ""}</div>`;
+    }).join("");
+  }
+
+  const teamContainer = document.getElementById("sim-equipe");
+  buildTeamSimulator(teamContainer, sprint);
+  updateTeamSimulator(teamContainer, sprint);
+
+  const profiles = sprint.individual?.profiles || [];
+  if (!profiles.length) state.campanhas.individualProfile = null;
+  if (profiles.length && !profiles.find(p => p.id === state.campanhas.individualProfile)) {
+    state.campanhas.individualProfile = profiles[0].id;
+  }
+  const profile = profiles.find(p => p.id === state.campanhas.individualProfile) || profiles[0] || null;
+  const individualContainer = document.getElementById("sim-individual");
+  buildIndividualSimulator(individualContainer, sprint, profile);
+  updateIndividualSimulator(individualContainer, sprint, profile);
+
+  const rankingContainer = document.getElementById("camp-ranking");
+  const rankingDesc = document.getElementById("camp-ranking-desc");
+  if (rankingDesc) {
+    const meta = rankingContext.levelInfo?.meta;
+    const plural = meta?.plural || "unidades";
+    const pluralLabel = plural.charAt(0).toUpperCase() + plural.slice(1);
+    rankingDesc.textContent = `Acompanhe a performance das ${pluralLabel} e a elegibilidade frente aos critérios mínimos.`;
+  }
+  renderCampaignRanking(rankingContainer, sprint, {
+    rows: aggregatedRows,
+    columnLabel: rankingContext.levelInfo?.meta?.singular || "Unidade"
+  });
+}
+
+
 function createRankingView(){
   const main = document.querySelector(".container"); 
   if(!main) return;
@@ -1953,11 +3866,20 @@ function createRankingView(){
 function currentUnitForLevel(level){
   const f=getFilterValues();
   switch(level){
-    case "gerente":  return f.gerente && f.gerente!=="Todos" ? f.gerente : "";
-    case "agencia":  return f.agencia && f.agencia!=="Todas" ? f.agencia : "";
-    case "gerencia": return f.gerencia && f.gerencia!=="Todas" ? f.gerencia : "";
-    case "diretoria":return f.diretoria && f.diretoria!=="Todas" ? f.diretoria : "";
-    default: return "";
+    case "gerente":
+      if (f.gerente && f.gerente!=="Todos") return f.gerente;
+      return CURRENT_USER_CONTEXT.gerente || "";
+    case "agencia":
+      if (f.agencia && f.agencia!=="Todas") return f.agencia;
+      return CURRENT_USER_CONTEXT.agencia || "";
+    case "gerencia":
+      if (f.gerencia && f.gerencia!=="Todas") return f.gerencia;
+      return CURRENT_USER_CONTEXT.gerencia || "";
+    case "diretoria":
+      if (f.diretoria && f.diretoria!=="Todas") return f.diretoria;
+      return CURRENT_USER_CONTEXT.diretoria || "";
+    default:
+      return "";
   }
 }
 function rkGroupCount(level){
@@ -1977,10 +3899,14 @@ function deriveRankingLevelFromFilters(){
 function aggRanking(rows, level){
   const keyMap = { diretoria:"diretoria", gerencia:"gerenciaRegional", agencia:"agencia", gerente:"gerente" };
   const k = keyMap[level] || "agencia";
+  const labelFieldMap = { diretoria:"diretoriaNome", gerencia:"gerenciaNome", agencia:"agenciaNome", gerente:"gerenteNome" };
+  const labelField = labelFieldMap[level] || k;
   const map = new Map();
   rows.forEach(r=>{
     const key=r[k] || "—";
-    const obj = map.get(key) || { unidade:key, real_mens:0, meta_mens:0, real_acum:0, meta_acum:0, qtd:0 };
+    const label = r[labelField] || key;
+    const obj = map.get(key) || { unidade:key, label, real_mens:0, meta_mens:0, real_acum:0, meta_acum:0, qtd:0 };
+    obj.label = label;
     obj.real_mens += (r.real_mens ?? r.realizado ?? 0);
     obj.meta_mens += (r.meta_mens ?? r.meta ?? 0);
     obj.real_acum += (r.real_acum ?? r.realizado ?? 0);
@@ -2016,6 +3942,10 @@ function renderRanking(){
   const myIndexFull = myUnit ? data.findIndex(d => d.unidade===myUnit) : -1;
   const myRankFull = myIndexFull>=0 ? (myIndexFull+1) : "—";
 
+  if (myUnit && myIndexFull >= 0 && !dataClamped.some(r => r.unidade === myUnit)) {
+    dataClamped.push(data[myIndexFull]);
+  }
+
   hostSum.innerHTML = `
     <div class="rk-badges">
       <span class="rk-badge"><strong>Nível:</strong> ${level.charAt(0).toUpperCase()+level.slice(1)}</span>
@@ -2036,8 +3966,6 @@ function renderRanking(){
         <th>Pontos (mensal)</th>
         <th>Pontos (acumulado)</th>
         <th>Atingimento</th>
-        <th>Realizado (R$)</th>
-        <th>Meta (R$)</th>
       </tr>
     </thead>
     <tbody></tbody>
@@ -2045,22 +3973,23 @@ function renderRanking(){
   const tb = tbl.querySelector("tbody");
 
   dataClamped.forEach((r,idx)=>{
+    const fullIndex = data.findIndex(d => d.unidade === r.unidade);
+    const rankNumber = fullIndex >= 0 ? (fullIndex + 1) : (idx + 1);
     const isMine = (myUnit && r.unidade === myUnit);
-    const nome = isMine ? r.unidade : "••••••••••";
+    const rawName = r.label || r.unidade || "—";
+    const visibleName = isMine ? rawName : "*****";
+    const nomeSafe = escapeHTML(visibleName);
+    const titleSafe = escapeHTML(isMine ? rawName : "Participante oculto");
     const ating = state.rk.mode === "acumulado" ? r.ating_acum : r.ating_mens;
-    const real  = state.rk.mode === "acumulado" ? r.real_acum : r.real_mens;
-    const meta  = state.rk.mode === "acumulado" ? r.meta_acum : r.meta_mens;
 
     const tr = document.createElement("tr");
     tr.className = `rk-row ${isMine? "rk-row--mine":""}`;
     tr.innerHTML = `
-      <td class="pos-col">${idx+1}</td>
-      <td class="unit-col rk-name">${nome}</td>
+      <td class="pos-col">${rankNumber}</td>
+      <td class="unit-col rk-name" title="${titleSafe}">${nomeSafe}</td>
       <td>${r.p_mens.toFixed(1)}</td>
       <td>${r.p_acum.toFixed(1)}</td>
       <td><span class="att-badge ${ating*100<50?"att-low":(ating*100<100?"att-warn":"att-ok")}">${(ating*100).toFixed(1)}%</span></td>
-      <td>${fmtBRL.format(real)}</td>
-      <td>${fmtBRL.format(meta)}</td>
     `;
     tb.appendChild(tr);
   });
@@ -2105,7 +4034,39 @@ function renderTreeTable() {
 
   let seq=0; const mkId=()=>`n${++seq}`;
   const att = (p)=>{ const pct=(p*100); const cls=pct<50?"att-low":(pct<100?"att-warn":"att-ok"); return `<span class="att-badge ${cls}">${pct.toFixed(1)}%</span>`; }
-  const defas = (real,meta)=>{ const d=(real||0)-(meta||0); const cls=d>=0?"def-pos":"def-neg"; return `<span class="def-badge ${cls}">${fmtBRL.format(d)}</span>`; }
+  const defas = (real,meta)=>{ const d=(real||0)-(meta||0); const cls=d>=0?"def-pos":"def-neg"; const full=fmtBRL.format(Math.round(d)); const display=formatBRLReadable(d); return `<span class="def-badge ${cls}" title="${full}">${display}</span>`; }
+
+  const buildDetailTableHTML = (groups=[]) => {
+    if (!groups || !groups.length) return "";
+    const fmtDate = iso => (iso ? formatBRDate(iso) : "—");
+    const rows = groups.map(g => `
+      <tr>
+        <td>${g.canal || "—"}</td>
+        <td>${g.tipo || "—"}</td>
+        <td>${g.gerente || "—"}</td>
+        <td>${g.modalidade || "—"}</td>
+        <td>${fmtDate(g.dataVencimento)}</td>
+        <td>${fmtDate(g.dataCancelamento)}</td>
+        <td>${g.motivoCancelamento || "—"}</td>
+      </tr>`).join("");
+    return `
+      <div class="tree-detail-wrapper">
+        <table class="detail-table">
+          <thead>
+            <tr>
+              <th>Canal da venda</th>
+              <th>Tipo da venda</th>
+              <th>Gerente</th>
+              <th>Condição de pagamento</th>
+              <th>Data de vencimento</th>
+              <th>Data de cancelamento</th>
+              <th>Motivo do cancelamento</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`;
+  };
 
   function renderNode(node, parentId=null, parentTrail=[]){
     const id=mkId(), has=!!(node.children&&node.children.length);
@@ -2113,14 +4074,32 @@ function renderTreeTable() {
     tr.className=`tree-row ${node.type==="contrato"?"type-contrato":""} lvl-${node.level}`;
     tr.dataset.id=id; if(parentId) tr.dataset.parent=parentId;
     const trail=[...parentTrail, node.label];
+    const hasDetails = node.type === "contrato" && Array.isArray(node.detailGroups) && node.detailGroups.length > 0;
+    let detailTr=null;
+
+    if (hasDetails) tr.classList.add("has-detail");
+
+    const labelBase = (node.type === "contrato" || !node.detail?.gerente)
+      ? node.label
+      : `Gerente: ${node.detail.gerente}`;
+    const labelHtml = node.detail
+      ? `<div class="tree-label"><span class="label-strong">${labelBase}</span></div>`
+      : `<span class="label-strong">${node.label}</span>`;
+
+    const qtyFull = fmtINT.format(Math.round(node.qtd || 0));
+    const qtyDisplay = formatIntReadable(node.qtd || 0);
+    const realizadoFull = fmtBRL.format(Math.round(node.realizado || 0));
+    const realizadoDisplay = formatBRLReadable(node.realizado || 0);
+    const metaFull = fmtBRL.format(Math.round(node.meta || 0));
+    const metaDisplay = formatBRLReadable(node.meta || 0);
 
     tr.innerHTML=`
       <td><div class="tree-cell">
         <button class="toggle" type="button" ${has?"":"disabled"} aria-label="${has?"Expandir/colapsar":""}"><i class="ti ${has?"ti-chevron-right":"ti-dot"}"></i></button>
-        <span class="label-strong">${node.label}</span></div></td>
-      <td>${fmtINT.format(node.qtd||0)}</td>
-      <td>${fmtBRL.format(node.realizado||0)}</td>
-      <td>${fmtBRL.format(node.meta||0)}</td>
+        ${labelHtml}</div></td>
+      <td><span title="${qtyFull}">${qtyDisplay}</span></td>
+      <td><span title="${realizadoFull}">${realizadoDisplay}</span></td>
+      <td><span title="${metaFull}">${metaDisplay}</span></td>
       <td>${defas(node.realizado,node.meta)}</td>
       <td>${att(node.ating||0)}</td>
       <td>${formatBRDate(node.data||"")}</td>
@@ -2151,6 +4130,28 @@ function renderTreeTable() {
     }
 
     tbody.appendChild(tr);
+
+    if (hasDetails){
+      detailTr=document.createElement("tr");
+      detailTr.className="tree-row tree-detail-row";
+      detailTr.dataset.detailParent=id;
+      detailTr.style.display="none";
+      detailTr.innerHTML=`<td colspan="8">${buildDetailTableHTML(node.detailGroups)}</td>`;
+      tbody.appendChild(detailTr);
+
+      tr.addEventListener("click", (ev)=>{
+        if (ev.target.closest('.toggle') || ev.target.closest('.icon-btn')) return;
+        const open = detailTr.style.display === "table-row";
+        if (open){
+          detailTr.style.display="none";
+          tr.classList.remove("is-detail-open");
+        } else {
+          detailTr.style.display="table-row";
+          tr.classList.add("is-detail-open");
+        }
+      });
+    }
+
     if(has){
       node.children.forEach(ch=>renderNode(ch, id, trail));
       toggleChildren(id, false);
@@ -2167,11 +4168,22 @@ function renderTreeTable() {
         toggleChildren(ch.dataset.id,false);
       }
     });
+    if(!show){
+      const detail=tbody.querySelector(`tr.tree-detail-row[data-detail-parent="${parentId}"]`);
+      if(detail){
+        detail.style.display="none";
+        const parentRow=tbody.querySelector(`tr[data-id="${parentId}"]`);
+        parentRow?.classList.remove("is-detail-open");
+      }
+    }
   }
 
   nodes.forEach(n=>renderNode(n,null,[]));
 }
-function applyFiltersAndRender(){ if(state.tableRendered) renderTreeTable(); }
+function applyFiltersAndRender(){
+  if(state.tableRendered) renderTreeTable();
+  if (state.activeView === "campanhas") renderCampanhasView();
+}
 function expandAllRows(){
   const tb=document.querySelector("#gridRanking tbody"); if(!tb) return;
   tb.querySelectorAll("tr").forEach(tr=>{
@@ -2267,13 +4279,14 @@ async function refresh(){
     const dataset = await getData();
     state._dataset = dataset;
     state._rankingRaw = dataset.ranking;
+    updateContractAutocomplete();
 
     const right = document.getElementById("lbl-atualizacao");
     if(right){
       right.innerHTML = `
         <div class="period-inline">
           <span class="txt">
-            Valores acumulados desde
+            De
             <strong><span id="lbl-periodo-inicio">${formatBRDate(state.period.start)}</span></strong>
             até
             <strong><span id="lbl-periodo-fim">${formatBRDate(state.period.end)}</span></strong>
@@ -2292,6 +4305,7 @@ async function refresh(){
 
     if (state.activeView==="ranking") renderRanking();
     if (state.activeView==="exec")    renderExecutiveView();
+    if (state.activeView==="campanhas") renderCampanhasView();
 
   }catch(e){
     console.error(e);
@@ -2307,6 +4321,7 @@ async function refresh(){
   injectStyles();
   initCombos();
   bindEvents();
+  initMobileCarousel();
   wireClearFiltersButton();
   ensureStatusFilterInAdvanced();
   reorderFiltersUI();

--- a/style.css
+++ b/style.css
@@ -187,6 +187,71 @@ html, body{ overflow:hidden; }           /* o scroll fica no .content */
   margin-bottom:16px;
 }
 .card__header{ display:flex; align-items:flex-start; justify-content:space-between; gap:12px; }
+.card__actions{ display:flex; align-items:center; gap:12px; position:relative; }
+.card__search-autocomplete{
+  position:relative;
+  flex:0 0 320px;
+  max-width:360px;
+  width:100%;
+}
+.card__search-autocomplete .input{ width:100%; }
+.card__search-autocomplete.is-loading::after{
+  content:"";
+  position:absolute;
+  top:50%;
+  right:12px;
+  width:16px;
+  height:16px;
+  border-radius:999px;
+  border:2px solid rgba(37,99,235,.35);
+  border-top-color:#2563eb;
+  animation:spin .8s linear infinite;
+  transform:translateY(-50%);
+}
+.card__search-autocomplete.is-loading .input{ padding-right:36px; }
+.contract-suggest{
+  position:absolute;
+  top:calc(100% + 6px);
+  left:0;
+  right:0;
+  background:#fff;
+  border:1px solid #d7def3;
+  border-radius:14px;
+  box-shadow:0 16px 32px rgba(17,23,41,.16);
+  padding:6px 0;
+  max-height:280px;
+  overflow-y:auto;
+  z-index:40;
+}
+.contract-suggest[hidden]{ display:none; }
+.contract-suggest__item{
+  width:100%;
+  padding:9px 16px;
+  background:transparent;
+  border:0;
+  text-align:left;
+  font-size:13px;
+  font-weight:700;
+  color:#1f2937;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  cursor:pointer;
+}
+.contract-suggest__item mark{
+  background:transparent;
+  color:#2563eb;
+  font-weight:800;
+}
+.contract-suggest__item:hover,
+.contract-suggest__item.is-highlight{ background:#eef2ff; color:#0f172a; }
+.contract-suggest__meta{ font-size:11.5px; color:#64748b; font-weight:600; }
+.contract-suggest__empty{
+  padding:10px 16px;
+  font-size:12.5px;
+  color:#6b7280;
+}
 .title-subtitle h2{ margin:0; }
 .muted{ color:var(--muted); }
 
@@ -223,11 +288,92 @@ select.input{
 }
 .tab{
   background:transparent; border:none; cursor:pointer;
-  padding:10px 12px; border-radius:8px 8px 0 0;
+  padding:10px 14px; border-radius:10px 10px 0 0;
   font-weight:700; color:#6b7280; border-bottom:3px solid transparent;
+  display:inline-flex; align-items:center; gap:8px;
+  transition:color .18s ease, border-color .18s ease;
 }
+.tab .tab-icon{ font-size:16px; }
+.tab .tab-label{ font-size:14px; }
 .tab.is-active{ color:var(--brand); border-bottom-color:var(--brand); }
 .tabs__aside{ margin-left:auto; color:var(--muted); }
+
+@media (max-width: 900px){
+  .tabs{
+    border-bottom:none;
+    display:grid;
+    grid-template-columns:repeat(auto-fit, minmax(140px,1fr));
+    gap:12px;
+    margin:16px 0;
+  }
+  .tab{
+    border:none;
+    border-radius:18px;
+    background:#fff;
+    box-shadow:0 12px 28px rgba(15,23,42,.12);
+    align-items:flex-start;
+    flex-direction:column;
+    gap:10px;
+    padding:16px 18px;
+    border:1px solid var(--stroke);
+  }
+  .tab .tab-icon{
+    width:40px; height:40px; border-radius:14px;
+    display:grid; place-items:center;
+    background:rgba(179,0,0,.12);
+    color:var(--brand);
+    font-size:20px;
+  }
+  .tab .tab-label{ font-size:15px; font-weight:700; color:#0f172a; }
+  .tab.is-active{
+    border-color:var(--brand);
+    box-shadow:0 16px 32px rgba(179,0,0,.18);
+  }
+  .tab.is-active .tab-icon{ background:var(--brand); color:#fff; }
+  .tab.is-active .tab-label{ color:var(--brand); }
+  .tabs__aside{ grid-column:1 / -1; justify-self:flex-end; }
+}
+
+@media (max-width: 640px){
+  .tabs{
+    display:grid;
+    grid-template-columns:repeat(5, minmax(0,1fr));
+    gap:6px;
+    margin:10px 0 16px;
+  }
+  .tab{
+    padding:10px 6px;
+    align-items:center;
+    justify-content:center;
+    text-align:center;
+    border-radius:14px;
+    gap:6px;
+  }
+  .tab .tab-icon{ width:26px; height:26px; font-size:16px; }
+  .tab .tab-label{ font-size:11px; }
+  .tabs__aside{ display:none; }
+}
+
+@media (max-width: 640px){
+  .card--filters .card__header{ flex-direction:column; align-items:flex-start; gap:16px; }
+  .card--filters .filters-hero{ width:100%; }
+  .card--filters .card__actions--mobile{ align-self:stretch; justify-content:flex-end; width:100%; }
+  .btn--mobile-filter{ width:44px; height:44px; padding:0; border-radius:14px; justify-content:center; }
+  .btn--mobile-filter i{ font-size:20px; }
+  .btn--mobile-filter .btn-label{ display:none; }
+  .card--filters.is-mobile-open .filters-mobile-close{
+    display:inline-flex;
+    position:sticky;
+    top:0;
+    margin-left:auto;
+    margin-bottom:16px;
+    width:40px;
+    height:40px;
+    border-radius:14px;
+    background:#fff;
+  }
+  .card--filters.is-mobile-open .filters-mobile-close i{ font-size:20px; }
+}
 
 /* =========================================================
    FILTROS
@@ -237,44 +383,231 @@ select.input{
   grid-template-columns:repeat(3, minmax(240px,1fr)) auto;
   gap:12px; align-items:end; margin-top:8px;
 }
+.filters-hero{ display:flex; flex-direction:column; gap:12px; min-width:0; }
+.mobile-carousel{ display:none; width:100%; position:relative; overflow:hidden; border-radius:20px; touch-action:pan-y; }
+.mobile-carousel__track{ position:relative; min-height:116px; }
+.mobile-carousel__slide{
+  display:none;
+  align-items:center;
+  gap:12px;
+  padding:14px 16px;
+  border-radius:18px;
+  background:linear-gradient(135deg, rgba(179,0,0,.9), rgba(179,0,0,.65));
+  color:#fff;
+  box-shadow:0 14px 28px rgba(179,0,0,.22);
+  min-height:116px;
+}
+.mobile-carousel__slide.is-active{ display:flex; }
+.mobile-carousel__icon{
+  width:46px; height:46px;
+  border-radius:14px;
+  background:rgba(255,255,255,.22);
+  display:grid; place-items:center;
+  font-size:22px;
+  flex-shrink:0;
+}
+.mobile-carousel__content{ display:flex; flex-direction:column; gap:4px; }
+.mobile-carousel__title{ margin:0; font-size:15px; font-weight:800; color:#fff; }
+.mobile-carousel__desc{ margin:0; font-size:12px; font-weight:600; color:rgba(255,255,255,.9); line-height:1.35; }
+.mobile-carousel__dots{ display:flex; justify-content:center; gap:6px; margin-top:10px; }
+.mobile-carousel__dot{
+  width:8px; height:8px;
+  border-radius:999px;
+  border:none;
+  background:rgba(255,255,255,.38);
+  cursor:pointer;
+  padding:0;
+}
+.mobile-carousel__dot[aria-current="true"]{
+  width:20px;
+  background:#fff;
+}
+.mobile-carousel__control{
+  position:absolute;
+  top:50%;
+  transform:translateY(-50%);
+  width:36px;
+  height:36px;
+  border-radius:12px;
+  border:1px solid rgba(255,255,255,.4);
+  background:rgba(15,23,42,.28);
+  color:#fff;
+  display:none;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  backdrop-filter:blur(6px);
+  z-index:5;
+}
+.mobile-carousel__control i{ font-size:18px; }
+.mobile-carousel__control--prev{ left:10px; }
+.mobile-carousel__control--next{ right:10px; }
 .filters__group label{ font-size:12px; color:var(--muted); display:block; margin-bottom:6px; }
 .filters__actions{ display:flex; gap:8px; justify-content:flex-end; }
 .filters__more--center{ display:flex; justify-content:center; align-items:center; margin-top:6px; }
+.btn--mobile-filter{ display:none; align-items:center; gap:6px; }
+.filters-mobile-close{ display:none; }
+.filters-backdrop{ display:none; }
 
 /* Filtros avanÃ§ados (slider) */
 .adv{ max-height:0; overflow:hidden; transition:max-height .35s ease; }
 .adv.is-open{ max-height:600px; }
 .adv__grid{ display:grid; grid-template-columns:repeat(3, minmax(240px,1fr)); gap:12px; align-items:end; padding-top:8px; }
 
+@media (max-width: 900px){
+  .btn--mobile-filter{ display:inline-flex; }
+  .card--filters{ position:relative; overflow:hidden; }
+  .card--filters .filters,
+  .card--filters .filters__actions,
+  .card--filters .filters__more,
+  .card--filters #advanced-filters{ display:none; }
+  .card--filters.is-mobile-open{
+    position:fixed;
+    inset:var(--topbar-h) 0 0 0;
+    z-index:1500;
+    background:#fff;
+    border-radius:24px 24px 0 0;
+    padding:24px 20px 32px;
+    max-width:none;
+    height:auto;
+    max-height:calc(100dvh - var(--topbar-h));
+    overflow-y:auto;
+    -webkit-overflow-scrolling:touch;
+  }
+  .card--filters.is-mobile-open .filters,
+  .card--filters.is-mobile-open .filters__actions,
+  .card--filters.is-mobile-open .filters__more,
+  .card--filters.is-mobile-open #advanced-filters{ display:block; }
+  .card--filters.is-mobile-open .filters{ display:grid; grid-template-columns:1fr; gap:12px; }
+  .card--filters.is-mobile-open .filters__actions{ flex-direction:column; align-items:stretch; }
+  .card--filters.is-mobile-open .filters__more{ justify-content:flex-start; margin-top:12px; }
+  .card--filters.is-mobile-open #advanced-filters{ max-height:none; padding-top:12px; }
+  .card--filters.is-mobile-open .card__actions--mobile{ display:none; }
+  .card--filters.is-mobile-open .filters-mobile-close{
+    display:inline-flex;
+    margin-left:auto;
+    margin-bottom:16px;
+    width:40px;
+    height:40px;
+    border-radius:14px;
+    background:#fff;
+  }
+  .card--filters.is-mobile-open .filters-mobile-close i{ font-size:20px; }
+  .filters-backdrop{ position:fixed; inset:0; background:rgba(15,20,36,.45); backdrop-filter:blur(2px); z-index:1400; display:none; }
+  .filters-backdrop.is-show{ display:block; }
+  body.filters-open{ overflow:hidden; }
+}
+
+@media (max-width: 768px){
+  .card--filters .title-subtitle{ display:none; }
+  .mobile-carousel{ display:block; }
+  .mobile-carousel__control{ display:grid; }
+}
+
 /* =========================================================
    KPI Topo (Big Numbers)
    ========================================================= */
 .kpi-summary{
-  display:flex; flex-wrap:wrap; gap:12px; margin:6px 0 8px;
+  display:flex;
+  flex-wrap:wrap;
+  gap:18px;
+  margin:8px 0 12px;
 }
 .kpi-pill{
-  background:#fff; border:1px solid #e5e7eb; border-radius:14px;
-  padding:12px 16px; box-shadow:0 6px 16px rgba(17,23,41,.06);
-  display:flex; align-items:center; gap:12px;
-  flex:1 1 350px; min-width:320px;
+  background:#fff;
+  border:2px solid #d7def3;
+  border-radius:20px;
+  padding:24px 26px;
+  box-shadow:0 12px 28px rgba(17,23,41,.12);
+  display:flex;
+  flex-direction:column;
+  align-items:flex-start;
+  gap:14px;
+  flex:1 1 360px;
+  min-width:320px;
+}
+.kpi-strip__main{
+  display:flex;
+  align-items:flex-start;
+  gap:14px;
+  width:100%;
+  min-width:0;
 }
 .kpi-icon{
-  width:28px; height:28px; border-radius:999px; display:grid; place-items:center;
-  background:#eef2ff; color:#1d4ed8;
+  width:44px;
+  height:44px;
+  border-radius:999px;
+  display:grid;
+  place-items:center;
+  background:#eef2ff;
+  color:#1d4ed8;
+  font-size:19px;
+  box-shadow:inset 0 0 0 1px rgba(29,78,216,.15);
+}
+.kpi-strip__text{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  min-width:0;
 }
 .kpi-strip__label{
-  font-weight:800; color:#111827; font-size:13px;
-  white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+  font-weight:800;
+  color:#111827;
+  font-size:14px;
+  line-height:1.1;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  max-width:240px;
 }
-.kpi-stat{ color:#64748b; font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.kpi-stat strong{ font-weight:600; color:#334155; }
-.hitbar{ display:flex; align-items:center; gap:8px; flex:1 1 200px; margin-left:auto; min-width:0; }
-.hitbar__track{ position:relative; flex:1 1 0; min-width:100px; height:10px; border-radius:999px; background:#eef2ff; border:1px solid #e5e7eb; overflow:hidden; }
+.kpi-strip__stats{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px 12px;
+  align-items:center;
+  min-width:0;
+}
+.kpi-stat{
+  color:#374151;
+  font-size:13px;
+  display:flex;
+  align-items:center;
+  gap:4px;
+  white-space:nowrap;
+}
+.kpi-stat strong{
+  font-weight:800;
+  color:#111827;
+}
+.hitbar{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  width:100%;
+  min-width:0;
+}
+.hitbar__track{
+  position:relative;
+  flex:1 1 auto;
+  min-width:0;
+  height:9px;
+  border-radius:999px;
+  background:#eef2ff;
+  border:1px solid #e5e7eb;
+  overflow:hidden;
+}
 .hitbar__fill{ position:absolute; left:0; top:0; bottom:0; width:0%; background:#bbf7d0; }
 .hitbar--low  .hitbar__fill{ background:#fecaca; }
 .hitbar--warn .hitbar__fill{ background:#fed7aa; }
-.hitbar strong{ font-size:12px; font-weight:700; color:#334155; }
-@media (max-width: 900px){ .kpi-pill{ flex:1 1 100%; min-width:100%; } }
+.hitbar strong{
+  font-size:12.5px;
+  font-weight:800;
+  color:#111827;
+  white-space:nowrap;
+}
+@media (max-width: 900px){
+  .kpi-pill{ flex:1 1 100%; min-width:100%; }
+}
 
 /* =========================================================
    SeÃ§Ãµes + grid de cards
@@ -283,14 +616,22 @@ select.input{
 .fam-section{ margin:22px 0 6px; }
 .fam-section__header{ display:flex; align-items:center; gap:12px; margin:0 2px 12px; }
 .fam-section__title{ font-weight:800; color:#1f2937; font-size:18px; display:flex; align-items:center; gap:10px; }
-.fam-section__meta{ color:#6b7280; font-weight:700; font-size:12.5px; white-space:nowrap; }
+.fam-section__meta{
+  color:#6b7280;
+  font-weight:700;
+  font-size:12.5px;
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+}
+.fam-section__meta-item{ white-space:nowrap; }
 .fam-section__grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(340px,1fr)); gap:16px; }
 
 /* Card de produto */
 .prod-card{
   position:relative; overflow:visible;
   background:#fff; border:1px solid var(--stroke); border-radius:18px;
-  padding:16px 16px 26px; box-shadow:var(--shadow);
+  padding:16px 16px 20px; box-shadow:var(--shadow);
   display:flex; flex-direction:column; gap:12px;
   transition:.18s ease transform,.18s ease box-shadow,.18s ease border-color;
   cursor:pointer;
@@ -328,8 +669,69 @@ select.input{
 .kv small{ display:block; color:#6b7280; font-size:12px; margin-bottom:4px; }
 .kv strong{ display:block; font-size:16px; line-height:1.15; white-space:nowrap; }
 
+/* Barra de variÃ¡vel */
+.prod-card__var{ display:flex; flex-direction:column; gap:6px; }
+.prod-card__var-head{ display:flex; align-items:center; justify-content:space-between; font-size:12px; color:#4b5563; }
+.prod-card__var-head strong{ font-size:13px; color:#111827; font-weight:800; }
+.prod-card__var-track{
+  position:relative;
+  display:flex;
+  align-items:center;
+  gap:10px;
+  min-height:24px;
+  border-radius:999px;
+  border:1px solid #e5e7eb;
+  background:#f8fafc;
+  padding:0 12px;
+  overflow:hidden;
+}
+.prod-card__var-fill{
+  position:absolute;
+  left:2px;
+  top:3px;
+  bottom:3px;
+  border-radius:999px;
+  transition:width .28s ease;
+}
+.prod-card__var-track.var--low .prod-card__var-fill{ background:#fecaca; }
+.prod-card__var-track.var--warn .prod-card__var-fill{ background:#fed7aa; }
+.prod-card__var-track.var--ok .prod-card__var-fill{ background:#bbf7d0; }
+.prod-card__var-label{ 
+  position:relative;
+  font-size:12px;
+  font-weight:800;
+  color:#334155;
+  white-space:nowrap;
+}
+.prod-card__var-label--current{ margin-right:auto; }
+.prod-card__var-label--target{ margin-left:auto; }
+
+@media (max-width: 640px){
+  .fam-section__grid{ gap:12px; }
+  .prod-card{ padding:14px 14px 16px; border-radius:16px; gap:10px; }
+  .prod-card__title i{ width:30px; height:30px; font-size:18px; }
+  .prod-card__meta{ font-size:11.5px; }
+  .prod-card__kpis{ gap:10px; }
+  .kv{ padding:8px 10px; }
+  .kv strong{ font-size:14px; }
+  .badge{ --size:46px; font-size:10px; }
+  .prod-card__var-track{ min-height:20px; padding:0 10px; }
+  .prod-card__var-head{ font-size:11px; }
+  .prod-card__var-head strong{ font-size:12px; }
+  .prod-card__var-label{ font-size:11px; }
+}
+
 /* RodapÃ© do card */
-.prod-card__foot{ position:absolute; right:12px; bottom:8px; font-size:11px; color:var(--muted); }
+.prod-card__foot{
+  margin-top:auto;
+  padding-top:6px;
+  font-size:11px;
+  color:var(--muted);
+  text-align:right;
+  align-self:flex-end;
+}
+
+.card--campanhas p{ margin:12px 0 0; }
 
 /* Tooltip dos cards */
 .kpi-tip{
@@ -402,6 +804,66 @@ select.input{
 }
 .toggle[disabled]{ opacity:.45; cursor:default; }
 .tree-table .label-strong{ font-weight:800; color:#111827; line-height:1.25; }
+.tree-label{ display:flex; flex-direction:column; gap:4px; }
+
+.tree-detail{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  margin-top:4px;
+}
+.tree-chip{
+  display:inline-flex;
+  align-items:center;
+  gap:4px;
+  padding:4px 10px;
+  border-radius:999px;
+  background:#eef2ff;
+  border:1px solid #dbeafe;
+  font-size:11px;
+  font-weight:700;
+  color:#475569;
+  white-space:nowrap;
+}
+.tree-chip strong{ font-weight:800; color:#1e293b; }
+
+.tree-row.has-detail{ cursor:pointer; }
+.tree-row.is-detail-open{ background:#f9fafb; }
+.tree-row.tree-detail-row td{
+  background:#f9fafb;
+  padding:14px 18px;
+  border-bottom:1px solid #e5e7eb;
+}
+.tree-row.tree-detail-row:last-of-type td{ border-bottom:none; }
+.tree-detail-wrapper{
+  background:#ffffff;
+  border:1px solid #e2e8f0;
+  border-radius:12px;
+  padding:12px;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.4);
+}
+.detail-table{ width:100%; border-collapse:collapse; font-size:12px; }
+.detail-table thead th{
+  text-align:center;
+  padding:6px 10px;
+  font-weight:800;
+  color:#475569;
+  border-bottom:1px solid #e5e7eb;
+}
+.detail-table thead th:first-child,
+.detail-table tbody td:first-child{
+  text-align:left;
+}
+.detail-table tbody td{
+  padding:6px 10px;
+  border-bottom:1px solid #f1f5f9;
+  color:#1f2937;
+  text-align:center;
+}
+.detail-table tbody tr:last-child td{ border-bottom:none; }
+.detail-table td.num{ text-align:right; white-space:nowrap; }
+.tree-detail-row .att-badge,
+.tree-detail-row .def-badge{ font-size:11px; }
 
 /* recuos por nÃ­vel */
 .tree-row.lvl-0 .tree-cell{ padding-left:8px; }
@@ -469,9 +931,14 @@ select.input{
 .rk-row--mine:hover{ background:#e8f4ff; }
 
 /* =========================================================
-   VISÃƒO EXECUTIVA (grÃ¡ficos + mini-ranks + ritmo)
+   VISÃO EXECUTIVA (gráficos + mini-ranks)
    ========================================================= */
-.card--exec{ padding-top:12px; }
+.card--exec{
+  padding-top:12px;
+  display:flex;
+  flex-direction:column;
+  gap:20px;
+}
 .exec-actions{ display:flex; gap:8px; flex-wrap:wrap; }
 
 .exec-kpis{
@@ -499,6 +966,21 @@ select.input{
   background:#fff; border:1px solid var(--stroke); border-radius:14px;
   padding:12px; box-shadow:var(--shadow);
 }
+.exec-head{ display:flex; align-items:flex-end; justify-content:space-between; gap:12px; }
+.seg-mini.segmented{ padding:2px; border-radius:8px; }
+.seg-mini .seg-btn{ padding:6px 8px; font-size:12px; }
+.exec-chart{
+  padding:20px;
+  box-sizing:border-box;
+  margin-bottom:12px;
+}
+.exec-chart .chart{
+  width:100%;
+  padding:20px;
+  border-radius:12px;
+  background:#fff;
+  box-sizing:border-box;
+}
 .exec-span-2{ grid-column: 1 / -1; }
 .exec-h{ margin:0 0 10px; font-size:14px; color:#374151; }
 
@@ -515,17 +997,7 @@ select.input{
 .rank-mini__pct{ text-align:right; }
 .rank-mini__vals{ text-align:right; color:#6b7280; font-weight:700; }
 
-/* ritmo */
-.ritmo-grid{ display:grid; grid-template-columns:repeat(2, minmax(200px,1fr)); gap:12px; align-items:end; }
-.ritmo-box{ background:#f8fafc; border:1px dashed #dde5ff; border-radius:12px; padding:10px 12px; }
-.ritmo-label{ color:#64748b; font-weight:700; font-size:12px; }
-.ritmo-val{ font-weight:800; font-size:18px; color:#111827; margin:4px 0; }
-.ritmo-bar{ height:10px; border-radius:999px; background:#dcfce7; border:1px solid #bbf7d0; overflow:hidden; }
-.ritmo-bar.ritmo-need{ background:#fee2e2; border-color:#fecaca; }
-.ritmo-bar span{ display:block; height:100%; width:100%; opacity:.7; }
-.ritmo-note{ grid-column:1 / -1; margin-top:2px; font-weight:800; }
-.ritmo-note.pos{ color:#166534; }
-.ritmo-note.neg{ color:#991b1b; }
+/* ritmo removido */
 
 /* heatmap */
 .hm{ display:flex; flex-direction:column; gap:4px; overflow:auto; }
@@ -564,7 +1036,14 @@ select.input{
    ========================================================= */
 /* Use .chart-card no painel com grÃ¡fico para espaÃ§ar menos */
 .chart-card{ padding:10px; }
-.chart-legend{ display:flex; align-items:center; gap:8px; margin-top:6px; font-size:11.5px; color:#6b7280; }
+.chart-legend{ display:flex; align-items:center; flex-wrap:wrap; gap:8px; margin-top:6px; font-size:11.5px; color:#6b7280; }
+.legend-item{ display:inline-flex; align-items:center; gap:6px; font-weight:700; color:#475569; }
+.legend-swatch{ width:14px; height:6px; border-radius:999px; background:#cbd5e1; border:1px solid #94a3b8; display:inline-block; }
+.legend-swatch--meta{ background:#93c5fd; border-color:#60a5fa; }
+.legend-swatch--real{ background:#86efac; border-color:#4ade80; }
+.legend-swatch--bars{ background:#e5e7eb; border-color:#cbd5e1; height:10px; }
+.legend-swatch--monthly-meta{ background:transparent; border:1.5px dashed #2563eb; height:8px; }
+.legend-swatch--monthly-real{ background:#2563eb; border-color:#1d4ed8; height:8px; }
 /* Ajuste de altura padrÃ£o; seu JS/Chart.js vai herdar do container */
 .chart-wrap{ height:260px; }
 
@@ -648,6 +1127,173 @@ select.input{
 .ac-id{ font-weight:800; color:#111827; }
 .ac-meta{ font-size:12px; color:#64748b; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 
+/* =========================================================
+   Campanhas
+   ========================================================= */
+.card--campanhas{ display:flex; flex-direction:column; gap:18px; }
+.camp-header{ align-items:flex-start; gap:18px; flex-wrap:wrap; }
+.camp-header__controls{ display:flex; flex-direction:column; align-items:flex-end; gap:6px; min-width:200px; }
+.camp-header__controls select{ min-width:200px; }
+
+.camp-hero{
+  display:flex; flex-wrap:wrap; gap:18px; align-items:stretch;
+  padding:18px; border:1px dashed rgba(179,0,0,.18);
+  border-radius:14px; background:linear-gradient(135deg, rgba(179,0,0,.08), rgba(179,0,0,.02));
+}
+.camp-hero__info{ flex:1 1 240px; display:flex; flex-direction:column; gap:10px; min-width:0; }
+.camp-hero__info p{ margin:0; font-size:14px; line-height:1.5; color:#1f2937; font-weight:600; }
+.camp-period{ display:inline-flex; align-items:center; gap:8px; font-weight:700; color:#111827; }
+.camp-period i{ color:var(--brand); font-size:16px; }
+
+.camp-hero__stats{ flex:1 1 200px; display:grid; grid-template-columns:repeat(auto-fit, minmax(140px,1fr)); gap:12px; }
+.camp-hero__stat{ background:#fff; border:1px solid rgba(179,0,0,.12); border-radius:12px; padding:12px; display:flex; flex-direction:column; gap:4px; box-shadow:0 10px 24px rgba(179,0,0,.08); }
+.camp-hero__stat span{ font-size:12px; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); font-weight:700; }
+.camp-hero__stat strong{ font-size:18px; color:#0f172a; }
+.camp-hero__stat small{ font-size:11px; color:#64748b; font-weight:600; }
+
+.camp-kpi-grid{ display:grid; grid-template-columns:repeat(auto-fit, minmax(180px,1fr)); gap:12px; }
+.camp-kpi{
+  background:#f8fafc; border:1px solid #e5e7eb; border-radius:14px;
+  padding:14px 16px; display:flex; flex-direction:column; gap:6px;
+}
+.camp-kpi span{ font-size:12px; text-transform:uppercase; letter-spacing:.04em; color:#6b7280; font-weight:700; }
+.camp-kpi strong{ font-size:18px; color:#0f172a; }
+.camp-kpi small{ font-size:11px; color:#64748b; font-weight:600; }
+
+.card--camp-sims{ display:flex; flex-direction:column; gap:16px; }
+.sim-grid{ display:grid; grid-template-columns:repeat(auto-fit, minmax(280px,1fr)); gap:18px; }
+.sim-card{ background:#fdfdff; border:2px solid #dbe2ff; border-radius:18px; padding:22px; display:flex; flex-direction:column; gap:18px; box-shadow:0 14px 30px rgba(15,23,42,.08); }
+.sim-card__head{ display:flex; flex-direction:column; gap:8px; }
+.sim-card__title{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.sim-card__head h5{ margin:0; font-size:19px; color:#0f172a; }
+.sim-card__head p{ margin:0; color:#4b5563; font-size:13px; line-height:1.5; }
+.sim-hint{ margin:0; color:#64748b; font-size:12px; font-weight:600; }
+.sim-help{ width:34px; height:34px; border-radius:12px; border:1px solid rgba(36,107,253,.25); background:rgba(36,107,253,.1); color:#246BFD; display:grid; place-items:center; cursor:pointer; transition:transform .15s ease, box-shadow .15s ease; }
+.sim-help:hover, .sim-help:focus-visible{ transform:translateY(-1px); box-shadow:0 10px 18px rgba(36,107,253,.18); outline:none; }
+.sim-help i{ font-size:18px; }
+
+.sim-presets{ display:flex; flex-wrap:wrap; gap:8px; }
+.sim-chip{
+  appearance:none; border:1px solid #d1d5db; border-radius:20px; padding:6px 12px; background:#fff;
+  color:#1f2937; font-weight:600; cursor:pointer; font-size:12px; transition:all .15s ease;
+}
+.sim-chip:hover{ box-shadow:0 8px 18px rgba(17,23,41,.1); transform:translateY(-1px); }
+.sim-chip.is-active{ border-color:#b30000; color:#b30000; background:rgba(179,0,0,.08); }
+
+.sim-table{ width:100%; border-collapse:collapse; }
+.sim-table th{ text-align:left; font-size:12px; font-weight:700; color:#6b7280; padding-bottom:8px; }
+.sim-table td{ padding:10px 0; border-bottom:1px solid #edf1f9; font-size:13px; color:#111827; vertical-align:middle; }
+.sim-table tr:last-child td{ border-bottom:none; }
+.sim-table td:last-child{ text-align:right; }
+
+.sim-weight{ font-weight:700; color:#0f172a; }
+.sim-points{ font-weight:700; color:#0f172a; }
+.sim-slider{ display:flex; align-items:center; gap:8px; }
+.sim-slider input[type="range"]{ flex:1 1 auto; accent-color:#b30000; }
+.sim-slider-value{ min-width:54px; text-align:right; font-weight:700; color:#111827; font-size:14px; }
+
+.status-pill{ display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; font-size:12px; font-weight:700; background:#f3f4f6; color:#1f2937; }
+.status-pill--great{ background:rgba(16,185,129,.15); color:#047857; }
+.status-pill--ok{ background:rgba(59,130,246,.18); color:#1d4ed8; }
+.status-pill--warn{ background:rgba(252,211,77,.25); color:#b45309; }
+.status-pill--alert{ background:rgba(248,113,113,.2); color:#b91c1c; }
+
+.status-tag{ display:inline-flex; align-items:center; gap:6px; padding:6px 14px; border-radius:999px; font-weight:800; font-size:12px; text-transform:uppercase; letter-spacing:.08em; }
+.status-tag--great{ background:linear-gradient(135deg, rgba(16,185,129,.16), rgba(16,185,129,.05)); color:#047857; }
+.status-tag--ok{ background:linear-gradient(135deg, rgba(59,130,246,.18), rgba(59,130,246,.05)); color:#1d4ed8; }
+.status-tag--warn{ background:linear-gradient(135deg, rgba(252,211,77,.25), rgba(252,211,77,.08)); color:#b45309; }
+.status-tag--alert{ background:linear-gradient(135deg, rgba(248,113,113,.3), rgba(248,113,113,.08)); color:#b91c1c; }
+
+.sim-summary{ display:flex; flex-wrap:wrap; align-items:center; gap:16px; justify-content:space-between; }
+.sim-total{ display:flex; flex-direction:column; gap:4px; }
+.sim-total span{ font-size:12px; color:#6b7280; font-weight:600; text-transform:uppercase; letter-spacing:.06em; }
+.sim-total strong{ font-size:24px; color:#0f172a; }
+
+.sim-progress{ flex:1 1 200px; display:flex; flex-direction:column; gap:6px; }
+.sim-progress__track{ height:10px; border-radius:999px; background:#e5e7eb; overflow:hidden; }
+.sim-progress__track span{ display:block; height:100%; border-radius:inherit; background:linear-gradient(90deg, #b30000, #f97316); transition:width .25s ease; }
+.sim-progress small{ font-size:12px; color:#6b7280; font-weight:600; }
+
+.sim-footnote{ margin:0; text-align:center; font-size:12px; }
+
+@media (max-width: 900px){
+  .sim-grid{ grid-template-columns:repeat(auto-fit, minmax(260px,1fr)); }
+}
+
+@media (max-width: 640px){
+  .sim-card{ padding:18px; }
+  .sim-progress{ flex-basis:100%; }
+}
+
+@media (max-width: 540px){
+  .sim-grid{ grid-template-columns:minmax(0,1fr); }
+}
+
+@media (max-width: 600px){
+  .sim-card{ padding:16px; gap:14px; }
+  .sim-card__head h5{ font-size:16px; }
+  .sim-card__head p{ font-size:13px; }
+  .sim-hint{ font-size:11.5px; }
+  .sim-table{ border-collapse:separate; border-spacing:0; }
+  .sim-table thead{ display:none; }
+  .sim-table tbody{ display:flex; flex-direction:column; gap:12px; }
+  .sim-table tbody tr{ display:flex; flex-direction:column; gap:10px; border:1px solid #eef2ff; border-radius:16px; padding:12px; background:#fff; box-shadow:0 8px 18px rgba(15,23,42,.06); }
+  .sim-table tbody td{ padding:0; border-bottom:none; font-size:13px; display:flex; align-items:center; justify-content:space-between; gap:12px; }
+  .sim-table tbody td + td{ margin-top:6px; }
+  .sim-table tbody td::before{ content:attr(data-label); font-size:11px; font-weight:700; color:#64748b; text-transform:uppercase; letter-spacing:.05em; }
+  .sim-table tbody td[data-label="Indicador"]{ flex-direction:column; align-items:flex-start; gap:4px; }
+  .sim-table tbody td[data-label="Indicador"]::before{ display:none; }
+  .sim-table tbody td[data-label="Atingimento"]{ flex-direction:column; align-items:flex-start; gap:8px; }
+  .sim-table tbody td[data-label="Atingimento"]::before{ margin-bottom:2px; }
+  .sim-slider{ width:100%; }
+  .sim-slider-value{ align-self:flex-end; }
+  .sim-table tbody td[data-label="Resultado"]{ justify-content:flex-start; }
+  .status-pill{ font-size:11px; padding:4px 10px; }
+  .sim-summary{ flex-direction:column; align-items:flex-start; gap:12px; }
+  .sim-total strong{ font-size:22px; }
+  .sim-progress{ width:100%; }
+}
+
+.scenario-table{ width:100%; border-collapse:collapse; }
+.scenario-table th{ text-align:left; font-size:11px; letter-spacing:.04em; text-transform:uppercase; color:#6b7280; padding-bottom:6px; }
+.scenario-table td{ padding:10px 0; border-bottom:1px solid #edf1f9; font-size:13px; }
+.scenario-table tr:last-child td{ border-bottom:none; }
+.scenario-table tr.is-active td{ background:rgba(179,0,0,.06); font-weight:600; }
+.scenario-actions{ text-align:right; }
+.scenario-actions button{ appearance:none; border:1px solid #d1d5db; border-radius:999px; padding:4px 10px; font-size:12px; font-weight:600; background:#fff; cursor:pointer; }
+.scenario-actions button:hover{ border-color:#b30000; color:#b30000; }
+
+.card--camp-ranking{ display:flex; flex-direction:column; gap:16px; }
+#camp-ranking{ overflow:auto; }
+.camp-ranking-table{ width:100%; min-width:760px; border-collapse:collapse; }
+.camp-ranking-table thead th{ padding:10px 12px; text-align:left; font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:.05em; color:#6b7280; border-bottom:1px solid #e5e7eb; }
+.camp-ranking-table tbody td{ padding:12px; border-bottom:1px solid #edf1f9; font-size:13px; color:#0f172a; }
+.camp-ranking-table tbody tr:hover{ background:#f8fafc; }
+.camp-ranking-table .pos-col{ width:56px; font-weight:800; text-align:center; }
+.camp-ranking-table .regional-col{ font-weight:700; }
+
+.indicator-bar{ display:flex; align-items:center; gap:10px; }
+.indicator-bar__track{ flex:1; height:6px; border-radius:999px; background:#e5e7eb; overflow:hidden; }
+.indicator-bar__track span{ display:block; height:100%; border-radius:inherit; background:linear-gradient(90deg, #2563eb, #38bdf8); }
+.indicator-bar__value{ min-width:58px; text-align:right; font-weight:700; }
+.indicator-bar__points{ font-size:11px; color:#64748b; font-weight:600; }
+
+.elegibility-badge{ display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:999px; font-weight:700; font-size:12px; }
+.elegibility-badge--great{ background:rgba(16,185,129,.16); color:#047857; }
+.elegibility-badge--ok{ background:rgba(59,130,246,.18); color:#1d4ed8; }
+.elegibility-badge--warn{ background:rgba(248,113,113,.2); color:#b91c1c; }
+
+@media (max-width: 860px){
+  .camp-hero{ padding:16px; }
+  .camp-hero__stats{ grid-template-columns:repeat(auto-fit, minmax(120px,1fr)); }
+}
+@media (max-width: 640px){
+  .camp-header__controls{ align-items:flex-start; width:100%; }
+  .camp-header__controls select{ width:100%; }
+  .sim-grid{ grid-template-columns:1fr; }
+  .camp-ranking-table{ min-width:640px; }
+}
+
 /* ===== Chat flutuante (widget) ===== */
 .chatw{ position: fixed; right: 16px; bottom: 16px; z-index: 1400; }
 .chatw__btn{
@@ -678,7 +1324,9 @@ select.input{
 .chatw__close{ border:0; background:#fff; border:1px solid #e5e7eb; border-radius:8px; width:30px; height:28px; cursor:pointer; }
 .chatw__close:hover{ box-shadow:0 6px 14px rgba(17,23,41,.08); }
 
-.chatw__msgs{ height: calc(520px - 48px - 56px); padding:12px; overflow:auto; background:#fafbff; }
+.chatw__disclaimer{ margin:0; padding:6px 12px; font-size:11px; color:#64748b; border-bottom:1px solid #eef2f7; background:#f8fafc; }
+
+.chatw__msgs{ height: calc(520px - 48px - 56px - 32px); padding:12px; overflow:auto; background:#fafbff; }
 .chatw__form{ height:56px; display:flex; gap:8px; align-items:center; padding:8px; border-top:1px solid #eef2f7; background:#fff; }
 #chat-input{
   flex:1 1 auto; border:1px solid #e5e7eb; border-radius:10px; padding:10px 12px; outline:none;
@@ -725,11 +1373,39 @@ select.input{
   .logo__text{ max-width:110px; }
   .userbox__name{ display:none; }
 }
+@media (max-width:640px){
+  .chart-card{ padding:14px; }
+  .chart-wrap{ height:220px; }
+  .exec-panel{ padding:14px; }
+}
+@media (max-width:768px){
+  .sidebar{ display:none !important; }
+  .sidebar-backdrop{ display:none !important; }
+  .content{ margin-left:0; }
+  #gridRanking{ overflow-x:auto; }
+  #gridRanking table{ min-width:720px; font-size:12px; }
+  .tree-table tbody td{ padding:10px 8px; }
+  .tree-table .tree-cell{ gap:8px; }
+  .tree-table .toggle{ width:26px; height:26px; }
+  .tree-table .icon-btn{ width:28px; height:28px; }
+  #rk-table{ overflow-x:auto; }
+  #rk-table table{ min-width:620px; font-size:12px; }
+  #rk-summary .rk-badge{ font-size:11px; }
+  .rk-table .unit-col{ max-width:180px; }
+  #rk-table .rk-name{ font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .exec-grid{ grid-template-columns:1fr; }
+  .rank-mini__row{ grid-template-columns:1fr; row-gap:6px; }
+  .rank-mini__pct, .rank-mini__vals{ text-align:left; }
+  .list-mini__row{ flex-direction:column; align-items:flex-start; gap:6px; }
+  #camp-ranking{ overflow-x:auto; }
+  #camp-ranking table{ min-width:700px; font-size:12px; }
+  .camp-hero__stats{ grid-template-columns:1fr; }
+}
 @media (max-width:560px){
   .container{ padding:0 12px; }
   .filters{ grid-template-columns:1fr; }
   .adv__grid{ grid-template-columns:1fr; }
-  .prod-card{ padding:14px 14px 24px; }
+  .prod-card{ padding:14px 14px 18px; }
   .kv strong{ font-size:15px; }
   .kpi-tip{ width: calc(100vw - 24px); right: auto; left: 12px; }
 }
@@ -804,3 +1480,12 @@ select.input{
 }
 
 
+.contract-suggest__empty{
+  padding:10px 16px;
+  font-size:12.5px;
+  color:#6b7280;
+}
+@media (max-width: 720px){
+  .card__actions{ flex-direction:column; align-items:stretch; }
+  .card__search-autocomplete{ flex:1 1 100%; max-width:100%; }
+}


### PR DESCRIPTION
## Summary
- add explicit previous/next controls to the mobile hero carousel and streamline the filter toggle/close buttons for phones
- tighten mobile styling for tabs, KPI cards and charts so cards fit within the viewport while keeping filters accessible
- adapt the simulators to render stacked cards on small screens with responsive CSS and data-label markup for readability

## Testing
- not run (manual only)

------
https://chatgpt.com/codex/tasks/task_e_68ce0fa276b08331994d36288f25bc49